### PR TITLE
Added Rating Sorting to Professor Formating Pipeline

### DIFF
--- a/packages/frontend/src/pages/TeacherPage.tsx
+++ b/packages/frontend/src/pages/TeacherPage.tsx
@@ -56,7 +56,15 @@ export function TeacherPage() {
             .filter(([department]) => department !== teacherData.department)
             .flatMap(([, classReviews]) => classReviews);
 
-        SetTeacherReviews([...primaryClasses, ...otherClasses]);
+        const sortedByDate = [...primaryClasses, ...otherClasses].map((classReview) => {
+            // Be carful the array is sorted in place. This is fine here but if moved could cause issues.
+            classReview.reviews.sort(
+                (a, b) => Date.parse(b.postDate.toString()) - Date.parse(a.postDate.toString()),
+            );
+            return classReview;
+        });
+
+        SetTeacherReviews(sortedByDate);
     }, [teacherData]);
 
     const history = useHistory();

--- a/packages/frontend/src/services/teacher.service.ts
+++ b/packages/frontend/src/services/teacher.service.ts
@@ -54,12 +54,6 @@ export class TeacherService {
         }
 
         const professor = await this.client.professors.get(id);
-        // Make sure reviews are in dated order
-        Object.values(professor.reviews ?? []).forEach((reviewArr) =>
-            reviewArr.sort(
-                (a, b) => Date.parse(b.postDate.toString()) - Date.parse(a.postDate.toString()),
-            ),
-        );
         this.addTeacherToCache(professor);
         return professor;
     }


### PR DESCRIPTION
This fixes ratings no longer being sorted once a rating is added to a teacher using the form.