### PR TITLE
Add anonymized identifiers to submitted reports

### DIFF
--- a/packages/backend/src/dao/auth-strategy.ts
+++ b/packages/backend/src/dao/auth-strategy.ts
@@ -67,6 +67,14 @@ export class AuthStrategy {
         return jwt.sign(payload, secret);
     }
 
+    async obfuscateIdentifier(id: string | null) {
+        const hashBuffer = await crypto.subtle.digest(
+            "SHA-256",
+            new TextEncoder().encode(id || ""),
+        );
+        return this.toHexString(new Uint8Array(hashBuffer)).substring(0, 16);
+    }
+
     // From: https://stackoverflow.com/questions/34309988/byte-array-to-hex-string-conversion-in-javascript
     private toHexString(byteArray: Uint8Array): string {
         return Array.from(byteArray, (byte) => `0${(byte & 0xff).toString(16)}`.slice(-2)).join("");

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -47,8 +47,11 @@ export default {
             createContext: async ({ req }) => {
                 const env = new Env(coudflareEnv);
                 const authHeader = req.headers.get("Authorization");
+                const anonymizedIdentifier = await env.authStrategy.obfuscateIdentifier(
+                    req.headers.get("CF-Connecting-IP"),
+                );
                 const user = await env.authStrategy.verify(authHeader);
-                return { env, user };
+                return { env, anonymizedIdentifier, user };
             },
             responseMeta: () => ({
                 headers: {

--- a/packages/backend/src/routers/rating.ts
+++ b/packages/backend/src/routers/rating.ts
@@ -79,6 +79,7 @@ export const ratingsRouter = t.router({
                     {
                         email: input.email,
                         reason: input.reason,
+                        anonymousIdentifier: ctx.anonymizedIdentifier,
                     },
                 ],
             };
@@ -87,6 +88,7 @@ export const ratingsRouter = t.router({
             await ctx.env.notificationDAO.sendWebhook(
                 "Received A Report",
                 `Rating ID: ${ratingReport.ratingId}\n` +
+                    `Submitter: ${ratingReport.reports[0].anonymousIdentifier}` +
                     `Professor ID: ${ratingReport.professorId}\n` +
                     `Reason: ${ratingReport.reports[0].reason}`,
             );

--- a/packages/backend/src/trpc.ts
+++ b/packages/backend/src/trpc.ts
@@ -6,6 +6,7 @@ type Context = {
     user?: {
         username: string;
     };
+    anonymizedIdentifier: string;
 };
 
 export const t = initTRPC.context<Context>().create({});

--- a/packages/backend/src/types/schema.ts
+++ b/packages/backend/src/types/schema.ts
@@ -91,6 +91,7 @@ export type User = z.infer<typeof userParser>;
 export const reportParser = z.object({
     email: z.nullable(z.string()),
     reason: z.string(),
+    anonymousIdentifier: z.optional(z.string()),
 });
 export const ratingReportParser = z.object({
     ratingId: z.string().uuid(),

--- a/packages/frontend/src/pages/Admin.tsx
+++ b/packages/frontend/src/pages/Admin.tsx
@@ -79,6 +79,9 @@ function ReportedRatings() {
                         // eslint-disable-next-line react/no-array-index-key
                         <Fragment key={idx + report.reason + report.email}>
                             {idx !== 0 && <div className="w-full h-1 bg-black my-2" />}
+                            {report.anonymousIdentifier && (
+                                <div>Submitted By: {report.anonymousIdentifier}</div>
+                            )}
                             {report.email && <div>Email: {report.email}</div>}
                             <div>Reason: {report.reason}</div>
                         </Fragment>


### PR DESCRIPTION
Sometimes we get mass reports of ratings, back-and-forth and back-and-forth. I want to know how much of it is noise we can just 'filter out' vs things we should act on.