### PR TITLE
Create admin operation to fix improperly escaped ratings

### DIFF
--- a/packages/backend/src/routers/admin.ts
+++ b/packages/backend/src/routers/admin.ts
@@ -118,7 +118,8 @@ export const adminRouter = t.router({
                 const professor = await ctx.env.kvDao.getProfessor(profId);
                 for (const [course, ratings] of Object.entries(professor.reviews)) {
                     professor.reviews[course] = ratings.map((rating) => {
-                        rating.rating = rating.rating.replaceAll("\\", "");
+                        // eslint-disable-next-line
+                        rating.rating = rating.rating.replaceAll("\\'", "'").replaceAll('\\"', '"');
                         return rating;
                     });
                 }


### PR DESCRIPTION
Sets up an operation to fix #38.

The following professor ids will be input as a part of the backfill to sanitize the ratings: https://pastebin.com/raw/jY0dj2d1. It's 1896 reviews overall, but this will run against 546 professors.

Assuming you're reading this before the daily sync cron jobs execute, feel free to go to https://beta.polyratings.pages.dev/professor/XXXXXX with any of those ids and compare against the live prod site.