### PR TITLE
Fix discord webhook

### DIFF
--- a/packages/backend/src/dao/discord-notification-dao.ts
+++ b/packages/backend/src/dao/discord-notification-dao.ts
@@ -19,7 +19,7 @@ export class DiscordNotificationDAO implements NotificationDAO {
         };
 
         // wait query-param will block for a response, or just accept a 204
-        await fetch(`${this.webhookURL}?"wait=true"`, {
+        await fetch(`${this.webhookURL}?wait=true`, {
             method: "POST",
             body: JSON.stringify(webhookBody),
             headers: {


### PR DESCRIPTION
Seems like the query param was bad. For some reason, this works in postman but now fetch. Probably has to do with the Cloudflare fetch impl. It most likely changed thinking it was just fixing broken behavior.