### PR TITLE
Feat: add grade distribution to professor page

### DIFF
--- a/packages/frontend/src/pages/ProfessorPage.tsx
+++ b/packages/frontend/src/pages/ProfessorPage.tsx
@@ -545,7 +545,7 @@ function getNumGrades(
 
             // increment total if grade matches OR if grade filter is "total" and current grade is not "N/A"
             if ((gradeFilter === "total" && currentGrade !== "N/A") || currentGrade === gradeFilter)
-                newTotal = newTotal + 1;
+                newTotal += 1;
         });
 
         return newTotal;

--- a/packages/frontend/src/pages/ProfessorPage.tsx
+++ b/packages/frontend/src/pages/ProfessorPage.tsx
@@ -292,7 +292,8 @@ function StatsCard({ professor, className = "" }: StatsCardProps) {
                 </div>
             </div>
             <div
-                className={`${getNumGrades(professor, "total") >= 20 ? "flex" : "hidden"} flex-col gap-1 justify-between font-medium bg-gray-200 px-3 py-2 rounded-sm mt-2`}
+                className={`flex-col gap-1 justify-between font-medium bg-gray-200 px-3 py-2 rounded-sm mt-2
+                    ${getNumGrades(professor, "total") >= 20 ? "flex" : "hidden"}`}
             >
                 <p className="min-w-max">Grade Distribution</p>
                 <div className="flex w-full items-center">
@@ -301,7 +302,8 @@ function StatsCard({ professor, className = "" }: StatsCardProps) {
                         .map((grade) => (
                             <div
                                 key={grade}
-                                className={`group relative flex justify-center first:rounded-l-md last:rounded-r-md border-2 border-r-0 border-gray-500/30 last:border-r-2
+                                className={`group relative flex justify-center first:rounded-l-md last:rounded-r-md 
+                                    border-2 border-r-0 border-gray-500/30 last:border-r-2
                                 ${getGradeColor(grade)}
                                 ${getNumGrades(professor, grade) === 0 ? "hidden" : ""}`}
                                 style={{ width: `${getPercentGrades(professor, grade)}%` }}
@@ -313,7 +315,8 @@ function StatsCard({ professor, className = "" }: StatsCardProps) {
                                 )}
 
                                 <div
-                                    className={`invisible group-hover:visible transition absolute top-7 left-1/2 -translate-x-1/2 transform whitespace-nowrap flex items-center justify-center rounded-md px-1.5 py-0.5 border-2 border-gray-500/30
+                                    className={`invisible group-hover:visible transition absolute top-7 left-1/2 -translate-x-1/2 transform 
+                                        whitespace-nowrap flex items-center justify-center rounded-md px-1.5 py-0.5 border-2 border-gray-500/30
                                         ${getGradeColor(grade)}`}
                                 >
                                     <p>
@@ -536,15 +539,16 @@ function getNumGrades(
     gradeFilter: string,
 ) {
     return Object.values(professor?.reviews || {}).reduce((total, reviews) => {
+        let newTotal = total;
         Object.values(reviews).forEach((r) => {
             const currentGrade = r.grade;
 
             // increment total if grade matches OR if grade filter is "total" and current grade is not "N/A"
             if ((gradeFilter === "total" && currentGrade !== "N/A") || currentGrade === gradeFilter)
-                total++;
+                newTotal = newTotal + 1;
         });
 
-        return total;
+        return newTotal;
     }, 0);
 }
 

--- a/packages/frontend/src/pages/ProfessorPage.tsx
+++ b/packages/frontend/src/pages/ProfessorPage.tsx
@@ -296,23 +296,36 @@ function StatsCard({ professor, className = "" }: StatsCardProps) {
             >
                 <p className="min-w-max">Grade Distribution</p>
                 <div className="flex w-full items-center">
-                    {["A", "B", "C", "D", "F", "CR", "NC", "W"].filter(grade => getNumGrades(professor, grade) > 0).map((grade) => (
-                        <div
-                            key={grade}
-                            className={`group relative flex justify-center first:rounded-l-md last:rounded-r-md
-                                ${grade == "A" ? "bg-blue-500/40" : grade == "B" ? "bg-green-500/40" : grade == "C" ? "bg-yellow-500/40" : grade == "D" ? "bg-orange-500/40" : grade == "F" ? "bg-red-500/40" : grade == "CR" ? "bg-slate-400/40" : grade == "NC" ? "bg-zinc-500/40" : grade == "W" ? "bg-stone-600/40" : ""} 
+                    {["A", "B", "C", "D", "F", "CR", "NC", "W"]
+                        .filter((grade) => getNumGrades(professor, grade) > 0)
+                        .map((grade) => (
+                            <div
+                                key={grade}
+                                className={`group relative flex justify-center first:rounded-l-md last:rounded-r-md border-2 border-r-0 border-gray-500/30 last:border-r-2
+                                ${getGradeColor(grade)}
                                 ${getNumGrades(professor, grade) === 0 ? "hidden" : ""}`}
-                            style={{width: `${getPercentGrades(professor, grade)}%`}}
-                        >
-                            {getPercentGrades(professor, grade) < 5 
-                                ? <span className="text-transparent">.</span>
-                                : <span>{grade}</span>}
+                                style={{ width: `${getPercentGrades(professor, grade)}%` }}
+                            >
+                                {getPercentGrades(professor, grade) < 5 ? (
+                                    <span className="text-transparent">.</span>
+                                ) : (
+                                    <span>{grade}</span>
+                                )}
 
-                            <div className={`invisible group-hover:visible transition absolute top-7 left-1/2 -translate-x-1/2 transform whitespace-nowrap flex items-center justify-center rounded-md px-1.5 py-0.5 border-2 border-gray-500/30 ${grade == "A" ? "bg-blue-200" : grade == "B" ? "bg-green-200" : grade == "C" ? "bg-yellow-200" : grade == "D" ? "bg-orange-200" : grade == "F" ? "bg-red-200" : grade == "CR" ? "bg-slate-100" : grade == "NC" ? "bg-zinc-200" : grade == "W" ? "bg-stone-300" : ""}`}>
-                                <p><span className="font-bold">{grade}:</span> {getNumGrades(professor, grade)} <span className="text-gray-700 text-sm">({getPercentGrades(professor, grade).toFixed(0)}%)</span></p>
+                                <div
+                                    className={`invisible group-hover:visible transition absolute top-7 left-1/2 -translate-x-1/2 transform whitespace-nowrap flex items-center justify-center rounded-md px-1.5 py-0.5 border-2 border-gray-500/30
+                                        ${getGradeColor(grade)}`}
+                                >
+                                    <p>
+                                        <span className="font-bold">{grade}:</span>{" "}
+                                        {getNumGrades(professor, grade)}{" "}
+                                        <span className="text-gray-700 text-sm">
+                                            ({getPercentGrades(professor, grade).toFixed(0)}%)
+                                        </span>
+                                    </p>
+                                </div>
                             </div>
-                        </div>
-                    ))}
+                        ))}
                 </div>
             </div>
         </div>
@@ -519,25 +532,51 @@ function ProfessorTag({ tagName }: ProfessorTagProps) {
 
 // return number of ratings that match given grade filter; if grade filter is "total," return number of ratings that have a grade that is not "N/A"
 function getNumGrades(
-  professor: inferProcedureOutput<AppRouter["professors"]["get"]> | undefined, gradeFilter: string
+    professor: inferProcedureOutput<AppRouter["professors"]["get"]> | undefined,
+    gradeFilter: string,
 ) {
-  return Object.values(professor?.reviews || {}).reduce((total, reviews) => {
-    Object.values(reviews).forEach((r) => {
-      const currentGrade = r.grade;
+    return Object.values(professor?.reviews || {}).reduce((total, reviews) => {
+        Object.values(reviews).forEach((r) => {
+            const currentGrade = r.grade;
 
-      // increment total if grade matches OR if grade filter is "total" and current grade is not "N/A"
-      if ((gradeFilter == "total" && currentGrade !== "N/A") || currentGrade == gradeFilter) 
-        total++;
-    });
+            // increment total if grade matches OR if grade filter is "total" and current grade is not "N/A"
+            if ((gradeFilter === "total" && currentGrade !== "N/A") || currentGrade === gradeFilter)
+                total++;
+        });
 
-    return total;
-  }, 0);
+        return total;
+    }, 0);
 }
 
 // return percentage of ratings that match given grade
 function getPercentGrades(
-    professor: inferProcedureOutput<AppRouter["professors"]["get"]> | undefined, grade: string
+    professor: inferProcedureOutput<AppRouter["professors"]["get"]> | undefined,
+    grade: string,
 ) {
     const total = getNumGrades(professor, "total");
     return total === 0 ? 0 : (getNumGrades(professor, grade) / total) * 100;
+}
+
+// get color from grade for grade distribution
+function getGradeColor(grade: string) {
+    switch (grade) {
+        case "A":
+            return "bg-blue-200";
+        case "B":
+            return "bg-green-200";
+        case "C":
+            return "bg-yellow-200";
+        case "D":
+            return "bg-orange-200";
+        case "F":
+            return "bg-red-200";
+        case "CR":
+            return "bg-slate-100";
+        case "NC":
+            return "bg-zinc-200";
+        case "W":
+            return "bg-stone-300";
+        default:
+            return "";
+    }
 }

--- a/packages/frontend/src/pages/ProfessorPage.tsx
+++ b/packages/frontend/src/pages/ProfessorPage.tsx
@@ -291,6 +291,24 @@ function StatsCard({ professor, className = "" }: StatsCardProps) {
                     </span>
                 </div>
             </div>
+            <div className={`${getNumGrades(professor, "total") === 0 ? "hidden" : "flex"} flex-col gap-1 justify-between font-medium bg-gray-200 px-3 py-2 rounded-sm mt-2`}>
+                <p className="min-w-max">Grade Distribution</p>
+                <div className="flex w-full items-center rounded-md overflow-hidden">
+                    {["A", "B", "C", "D", "F", "CR", "NC", "W"].map((grade) => (
+                        <div
+                            key={grade}
+                            className={`flex justify-center 
+                                ${grade == "A" ? "bg-blue-500/40" : grade == "B" ? "bg-green-500/40" : grade == "C" ? "bg-yellow-500/40" : grade == "D" ? "bg-orange-500/40" : grade == "F" ? "bg-red-500/40" : grade == "CR" ? "bg-slate-400/40" : grade == "NC" ? "bg-zinc-500/40" : grade == "W" ? "bg-stone-600/40" : ""}${" "}
+                                ${getNumGrades(professor, grade) === 0 ? "hidden" : ""}`}
+                            style={{width: `${getPercentGrades(professor, grade)}%`}}
+                        >
+                            <span className={getPercentGrades(professor, grade) < 5 ? "text-transparent" : ""}>
+                                {grade}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            </div>
         </div>
     );
 }
@@ -491,4 +509,29 @@ function ProfessorTag({ tagName }: ProfessorTagProps) {
             <span className="font-medium ml-1 md:ml-2">{tagName}</span>
         </div>
     );
+}
+
+// return number of ratings that match given grade filter; if grade filter is "total," return number of ratings that have a grade that is not "N/A"
+function getNumGrades(
+  professor: inferProcedureOutput<AppRouter["professors"]["get"]> | undefined, gradeFilter: string
+) {
+  return Object.values(professor?.reviews || {}).reduce((total, reviews) => {
+    Object.values(reviews).forEach((r) => {
+      const currentGrade = r.grade;
+
+      // increment total if grade matches OR if grade filter is "total" and current grade is not "N/A"
+      if ((gradeFilter == "total" && currentGrade !== "N/A") || currentGrade == gradeFilter) 
+        total++;
+    });
+
+    return total;
+  }, 0);
+}
+
+// return percentage of ratings that match given grade
+function getPercentGrades(
+    professor: inferProcedureOutput<AppRouter["professors"]["get"]> | undefined, grade: string
+) {
+    const total = getNumGrades(professor, "total");
+    return total === 0 ? 0 : (getNumGrades(professor, grade) / total) * 100;
 }

--- a/packages/frontend/src/pages/ProfessorPage.tsx
+++ b/packages/frontend/src/pages/ProfessorPage.tsx
@@ -291,7 +291,9 @@ function StatsCard({ professor, className = "" }: StatsCardProps) {
                     </span>
                 </div>
             </div>
-            <div className={`${getNumGrades(professor, "total") === 0 ? "hidden" : "flex"} flex-col gap-1 justify-between font-medium bg-gray-200 px-3 py-2 rounded-sm mt-2`}>
+            <div
+                className={`${getNumGrades(professor, "total") >= 20 ? "flex" : "hidden"} flex-col gap-1 justify-between font-medium bg-gray-200 px-3 py-2 rounded-sm mt-2`}
+            >
                 <p className="min-w-max">Grade Distribution</p>
                 <div className="flex w-full items-center">
                     {["A", "B", "C", "D", "F", "CR", "NC", "W"].filter(grade => getNumGrades(professor, grade) > 0).map((grade) => (

--- a/packages/frontend/src/pages/ProfessorPage.tsx
+++ b/packages/frontend/src/pages/ProfessorPage.tsx
@@ -293,18 +293,22 @@ function StatsCard({ professor, className = "" }: StatsCardProps) {
             </div>
             <div className={`${getNumGrades(professor, "total") === 0 ? "hidden" : "flex"} flex-col gap-1 justify-between font-medium bg-gray-200 px-3 py-2 rounded-sm mt-2`}>
                 <p className="min-w-max">Grade Distribution</p>
-                <div className="flex w-full items-center rounded-md overflow-hidden">
-                    {["A", "B", "C", "D", "F", "CR", "NC", "W"].map((grade) => (
+                <div className="flex w-full items-center">
+                    {["A", "B", "C", "D", "F", "CR", "NC", "W"].filter(grade => getNumGrades(professor, grade) > 0).map((grade) => (
                         <div
                             key={grade}
-                            className={`flex justify-center 
-                                ${grade == "A" ? "bg-blue-500/40" : grade == "B" ? "bg-green-500/40" : grade == "C" ? "bg-yellow-500/40" : grade == "D" ? "bg-orange-500/40" : grade == "F" ? "bg-red-500/40" : grade == "CR" ? "bg-slate-400/40" : grade == "NC" ? "bg-zinc-500/40" : grade == "W" ? "bg-stone-600/40" : ""}${" "}
+                            className={`group relative flex justify-center first:rounded-l-md last:rounded-r-md
+                                ${grade == "A" ? "bg-blue-500/40" : grade == "B" ? "bg-green-500/40" : grade == "C" ? "bg-yellow-500/40" : grade == "D" ? "bg-orange-500/40" : grade == "F" ? "bg-red-500/40" : grade == "CR" ? "bg-slate-400/40" : grade == "NC" ? "bg-zinc-500/40" : grade == "W" ? "bg-stone-600/40" : ""} 
                                 ${getNumGrades(professor, grade) === 0 ? "hidden" : ""}`}
                             style={{width: `${getPercentGrades(professor, grade)}%`}}
                         >
-                            <span className={getPercentGrades(professor, grade) < 5 ? "text-transparent" : ""}>
-                                {grade}
-                            </span>
+                            {getPercentGrades(professor, grade) < 5 
+                                ? <span className="text-transparent">.</span>
+                                : <span>{grade}</span>}
+
+                            <div className={`invisible group-hover:visible transition absolute top-7 left-1/2 -translate-x-1/2 transform whitespace-nowrap flex items-center justify-center rounded-md px-1.5 py-0.5 border-2 border-gray-500/30 ${grade == "A" ? "bg-blue-200" : grade == "B" ? "bg-green-200" : grade == "C" ? "bg-yellow-200" : grade == "D" ? "bg-orange-200" : grade == "F" ? "bg-red-200" : grade == "CR" ? "bg-slate-100" : grade == "NC" ? "bg-zinc-200" : grade == "W" ? "bg-stone-300" : ""}`}>
+                                <p><span className="font-bold">{grade}:</span> {getNumGrades(professor, grade)} <span className="text-gray-700 text-sm">({getPercentGrades(professor, grade).toFixed(0)}%)</span></p>
+                            </div>
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
## Changes
- Adds a grade distribution bar on professor page

## Purpose
Ratings are subjective and don't always correlate to an easier/harder class. Currently, the user has to check every grade in every evaluation to get an objective understanding of the professor's difficulty. A visual summary of grades at the top of the page can be helpful for quickly getting a more objective overview of a professor.

## Images
**Example 1**
<img width="1619" height="1009" alt="Screenshot 2026-02-16 at 14 21 13" src="https://github.com/user-attachments/assets/039b80f1-9c48-4286-865f-3140ba744840" />

**Example 2**      |  **Example 3**
:-----------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------:
![image](https://github.com/user-attachments/assets/fdce04c2-c0a5-4994-a9db-74a31f59af06) | ![image](https://github.com/user-attachments/assets/6de811d5-d1e5-4209-aef2-8bf919239092)
**Example 4 (hover)**        |  **Example 5 (hover)**
![image](https://github.com/user-attachments/assets/3fe756ed-3659-4ee4-9dd5-760dbdd4c772) | ![image](https://github.com/user-attachments/assets/927ed772-344a-40e7-bf5e-5fca67a58084)
