### PR TITLE
fix(backend): normalize tRPC errors and stale-id route behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ This repository is a **Lerna monorepo** with Nx for task orchestration. It conta
 - **Styling:** Tailwind CSS. Write CSS inline via Tailwind classes.
 - **Module pattern:** Use `index.ts` per folder to re-export; avoid `../` imports when possible (restricted by ESLint).
 - **API:** tRPC for type-safe client–server calls; TanStack Query for caching.
+- **Error handling:** Prefer local, contextual error UX at the query/mutation site (inline messages for page sections and forms). Keep global toasts as a fallback safety net only.
+- **Global toast suppression:** When a query/mutation already has local error handling, set query/mutation `meta.suppressGlobalErrorToast = true` (or provide explicit `onError`) to avoid duplicate notifications.
 - **Components:** One public component per file; co-locate styles with components.
 
 ### Backend (`packages/backend/`)
@@ -57,6 +59,7 @@ This repository is a **Lerna monorepo** with Nx for task orchestration. It conta
 - **Build:** `npm run build` runs `generateBackendTypes.js`, tsc, then esbuild.
 - **Public API data safety:** treat `anonymousIdentifier` as sensitive metadata. Public procedures (plain `t.procedure`) must return sanitized/public schemas that omit sensitive keys. Only protected procedures (`protectedProcedure`) may return schemas that include `anonymousIdentifier` when needed.
 - **Schema pattern:** keep both full/internal and public-safe Zod schemas in `src/types/schema.ts` (for example `ratingParser` vs `publicRatingParser`, `professorParser` vs `publicProfessorParser`) and use helper mappers in `src/types/schemaHelpers.ts` before returning data from public routers.
+- **Route error semantics:** For protected/admin routes, prefer explicit `TRPCError` responses (for example `NOT_FOUND`) when IDs are stale/missing. For public report flows affected by stale client cache, prefer graceful no-op behavior.
 
 ### General
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ This repository is a **Lerna monorepo** with Nx for task orchestration. It conta
 - **Entry:** `src/index.ts` sets up tRPC router.
 - **Structure:** `routers/` (handlers), `dao/` (data access over KV), `types/` (KV schema).
 - **Build:** `npm run build` runs `generateBackendTypes.js`, tsc, then esbuild.
-- **Public API data safety:** treat `anonymousIdentifier` as sensitive metadata. Public procedures (plain `t.procedure`) must return sanitized/public schemas that omit sensitive keys. Only protected procedures (`protectedProcedure`) may return schemas that include `anonymousIdentifier` when needed.
+- **Public API data safety:** treat `anonymousIdentifier` as sensitive metadata. Public routes should use `publicProcedure` and must return sanitized/public schemas that omit sensitive keys. Only protected procedures (`protectedProcedure`) may return schemas that include `anonymousIdentifier` when needed.
 - **Schema pattern:** keep both full/internal and public-safe Zod schemas in `src/types/schema.ts` (for example `ratingParser` vs `publicRatingParser`, `professorParser` vs `publicProfessorParser`) and use helper mappers in `src/types/schemaHelpers.ts` before returning data from public routers.
 - **Route error semantics:** For protected/admin routes, prefer explicit `TRPCError` responses (for example `NOT_FOUND`) when IDs are stale/missing. For public report flows affected by stale client cache, prefer graceful no-op behavior.
 

--- a/packages/backend/src/dao/kv-dao.ts
+++ b/packages/backend/src/dao/kv-dao.ts
@@ -60,6 +60,10 @@ export class KVDAO {
         return this.polyratingsNamespace.get(professorParser, id);
     }
 
+    getProfessorOptional(id: string) {
+        return this.polyratingsNamespace.getOptional(professorParser, id);
+    }
+
     getBulkNamespace(bulkKey: BulkKey): { namespace: KvWrapper; parser: z.ZodTypeAny } {
         const namespaceMap: Record<BulkKey, { namespace: KvWrapper; parser: z.ZodTypeAny }> = {
             professors: { namespace: this.polyratingsNamespace, parser: professorParser },
@@ -186,6 +190,11 @@ export class KVDAO {
 
     async removeRating(professorId: string, ratingId: string) {
         const professor = await this.getProfessor(professorId);
+        return this.removeRatingWithProfessor(professor, ratingId);
+    }
+
+    /** Mutates the given professor snapshot and persists it (avoids a redundant KV read). */
+    removeRatingWithProfessor(professor: Professor, ratingId: string) {
         removeRating(professor, ratingId);
         return this.putProfessor(professor);
     }
@@ -217,6 +226,10 @@ export class KVDAO {
         return this.professorApprovalQueueNamespace.get(professorParser, id);
     }
 
+    getPendingProfessorOptional(id: string) {
+        return this.professorApprovalQueueNamespace.getOptional(professorParser, id);
+    }
+
     async getAllPendingProfessors() {
         return this.professorApprovalQueueNamespace.getAll(professorParser);
     }
@@ -227,6 +240,10 @@ export class KVDAO {
 
     async getReport(ratingId: string) {
         return this.reportsNamespace.get(ratingReportParser, ratingId);
+    }
+
+    getReportOptional(ratingId: string) {
+        return this.reportsNamespace.getOptional(ratingReportParser, ratingId);
     }
 
     async putReport(report: RatingReport): Promise<void> {

--- a/packages/backend/src/dao/kv-wrapper.ts
+++ b/packages/backend/src/dao/kv-wrapper.ts
@@ -27,8 +27,11 @@ export class KvWrapper {
         try {
             const value = await this.get(parser, key);
             return value;
-        } catch {
-            return undefined;
+        } catch (error) {
+            if (error instanceof TRPCError && error.code === "NOT_FOUND") {
+                return undefined;
+            }
+            throw error;
         }
     }
 

--- a/packages/backend/src/routers/admin.ts
+++ b/packages/backend/src/routers/admin.ts
@@ -2,6 +2,8 @@ import { t, protectedProcedure } from "@backend/trpc";
 import { z } from "zod";
 import { addRating } from "@backend/types/schemaHelpers";
 import { bulkKeys, DEPARTMENT_LIST } from "@backend/utils/const";
+import { TRPCError } from "@trpc/server";
+import { Professor, RatingReport } from "@backend/types/schema";
 
 const changeDepartmentParser = z.object({
     professorId: z.uuid(),
@@ -31,6 +33,58 @@ const DISCORD_MESSAGE_MAX_LENGTH = 2000;
 const MAX_IDS_IN_AUDIT = 10;
 const MAX_REASON_LENGTH = 600;
 
+function getProfessorRatingIds(professor: Professor): Set<string> {
+    return new Set(
+        Object.values(professor.reviews).flatMap((ratings) => ratings.map((rating) => rating.id)),
+    );
+}
+
+async function requireProfessor(
+    ctx: { env: { kvDao: { getProfessorOptional(id: string): Promise<Professor | undefined> } } },
+    professorId: string,
+): Promise<Professor> {
+    const professor = await ctx.env.kvDao.getProfessorOptional(professorId);
+    if (!professor) {
+        throw new TRPCError({
+            code: "NOT_FOUND",
+            message: `Professor with id ${professorId} does not exist.`,
+        });
+    }
+    return professor;
+}
+
+async function requirePendingProfessor(
+    ctx: {
+        env: {
+            kvDao: { getPendingProfessorOptional(id: string): Promise<Professor | undefined> };
+        };
+    },
+    professorId: string,
+): Promise<Professor> {
+    const professor = await ctx.env.kvDao.getPendingProfessorOptional(professorId);
+    if (!professor) {
+        throw new TRPCError({
+            code: "NOT_FOUND",
+            message: `Pending professor with id ${professorId} does not exist.`,
+        });
+    }
+    return professor;
+}
+
+async function requireReport(
+    ctx: { env: { kvDao: { getReportOptional(id: string): Promise<RatingReport | undefined> } } },
+    reportId: string,
+): Promise<RatingReport> {
+    const report = await ctx.env.kvDao.getReportOptional(reportId);
+    if (!report) {
+        throw new TRPCError({
+            code: "NOT_FOUND",
+            message: `Report for rating id ${reportId} does not exist.`,
+        });
+    }
+    return report;
+}
+
 function buildBulkDeletionAuditMessage(
     username: string,
     removed: number,
@@ -59,9 +113,17 @@ function buildBulkDeletionAuditMessage(
 
 export const adminRouter = t.router({
     removeRating: protectedProcedure
-        .input(z.object({ professorId: z.string(), ratingId: z.string() }))
+        .input(z.object({ professorId: z.uuid(), ratingId: z.uuid() }))
         .mutation(async ({ ctx, input: { professorId, ratingId } }) => {
-            await ctx.env.kvDao.removeRating(professorId, ratingId);
+            const professor = await requireProfessor(ctx, professorId);
+            if (!getProfessorRatingIds(professor).has(ratingId)) {
+                throw new TRPCError({
+                    code: "NOT_FOUND",
+                    message: `Rating with id ${ratingId} does not exist on professor ${professorId}.`,
+                });
+            }
+            await ctx.env.kvDao.removeRatingWithProfessor(professor, ratingId);
+            await ctx.env.kvDao.removeReport(ratingId);
         }),
     removeRatingsBulk: protectedProcedure
         .input(
@@ -79,15 +141,18 @@ export const adminRouter = t.router({
             }),
         )
         .mutation(async ({ ctx, input: { professorId, ratingIds, reason } }) => {
-            const professor = await ctx.env.kvDao.getProfessor(professorId);
-            const existingRatingIds = new Set(
-                Object.values(professor.reviews).flatMap((ratings) =>
-                    ratings.map((rating) => rating.id),
-                ),
-            );
+            const professor = await requireProfessor(ctx, professorId);
+            const existingRatingIds = getProfessorRatingIds(professor);
             const removedRatingIds = [
                 ...new Set(ratingIds.filter((ratingId) => existingRatingIds.has(ratingId))),
             ];
+            if (removedRatingIds.length === 0) {
+                throw new TRPCError({
+                    code: "NOT_FOUND",
+                    message:
+                        "None of the requested ratings exist on this professor. They may have already been deleted.",
+                });
+            }
             const removed = await ctx.env.kvDao.removeRatingsBulk(professor, ratingIds);
             await Promise.all(
                 removedRatingIds.map((ratingId) => ctx.env.kvDao.removeReport(ratingId)),
@@ -107,7 +172,7 @@ export const adminRouter = t.router({
         ctx.env.kvDao.getAllPendingProfessors(),
     ),
     approvePendingProfessor: protectedProcedure.input(z.uuid()).mutation(async ({ ctx, input }) => {
-        const pendingProfessor = await ctx.env.kvDao.getPendingProfessor(input);
+        const pendingProfessor = await requirePendingProfessor(ctx, input);
 
         await ctx.env.kvDao.putProfessor(pendingProfessor);
         await ctx.env.kvDao.removePendingProfessor(input);
@@ -123,8 +188,10 @@ export const adminRouter = t.router({
     mergeProfessor: protectedProcedure
         .input(z.object({ destId: z.uuid(), sourceId: z.uuid() }))
         .mutation(async ({ ctx, input: { destId, sourceId } }) => {
-            const destProfessor = await ctx.env.kvDao.getProfessor(destId);
-            const sourceProfessor = await ctx.env.kvDao.getProfessor(sourceId);
+            const [destProfessor, sourceProfessor] = await Promise.all([
+                requireProfessor(ctx, destId),
+                requireProfessor(ctx, sourceId),
+            ]);
 
             Object.entries(sourceProfessor.reviews).forEach(([course, ratings]) => {
                 ratings.forEach((rating) => addRating(destProfessor, rating, course));
@@ -136,21 +203,21 @@ export const adminRouter = t.router({
     changeProfessorDepartment: protectedProcedure
         .input(changeDepartmentParser)
         .mutation(async ({ ctx, input: { professorId, department } }) => {
-            const professor = await ctx.env.kvDao.getProfessor(professorId);
+            const professor = await requireProfessor(ctx, professorId);
             professor.department = department;
             await ctx.env.kvDao.putProfessor(professor);
         }),
     changePendingProfessorDepartment: protectedProcedure
         .input(changeDepartmentParser)
         .mutation(async ({ ctx, input: { professorId, department } }) => {
-            const professor = await ctx.env.kvDao.getPendingProfessor(professorId);
+            const professor = await requirePendingProfessor(ctx, professorId);
             professor.department = department;
             await ctx.env.kvDao.putPendingProfessor(professor);
         }),
     changeProfessorName: protectedProcedure
         .input(changeNameParser)
         .mutation(async ({ ctx, input: { professorId, firstName, lastName } }) => {
-            const professor = await ctx.env.kvDao.getProfessor(professorId);
+            const professor = await requireProfessor(ctx, professorId);
             professor.firstName = firstName;
             professor.lastName = lastName;
             await ctx.env.kvDao.putProfessor(professor, true);
@@ -158,7 +225,7 @@ export const adminRouter = t.router({
     changePendingProfessorName: protectedProcedure
         .input(changeNameParser)
         .mutation(async ({ ctx, input: { professorId, firstName, lastName } }) => {
-            const professor = await ctx.env.kvDao.getPendingProfessor(professorId);
+            const professor = await requirePendingProfessor(ctx, professorId);
             professor.firstName = firstName;
             professor.lastName = lastName;
             await ctx.env.kvDao.putPendingProfessor(professor);
@@ -166,7 +233,7 @@ export const adminRouter = t.router({
     lockProfessor: protectedProcedure
         .input(lockProfessorParser)
         .mutation(async ({ ctx, input: { professorId, locked, lockedMessage } }) => {
-            const professor = await ctx.env.kvDao.getProfessor(professorId);
+            const professor = await requireProfessor(ctx, professorId);
             professor.locked = locked;
             professor.lockedMessage = locked ? lockedMessage : undefined;
             await ctx.env.kvDao.putProfessor(professor);
@@ -177,23 +244,39 @@ export const adminRouter = t.router({
     // Mark as mutation to not have url issues
     getBulkValues: protectedProcedure
         .input(z.object({ bulkKey: z.enum(bulkKeys), keys: z.string().array() }))
-        .mutation(async ({ ctx, input: { bulkKey, keys } }) =>
+        .mutation(({ ctx, input: { bulkKey, keys } }) =>
             ctx.env.kvDao.getBulkValues(bulkKey, keys),
         ),
     removeReport: protectedProcedure.input(z.uuid()).mutation(async ({ ctx, input }) => {
         await ctx.env.kvDao.removeReport(input);
     }),
     actOnReport: protectedProcedure.input(z.uuid()).mutation(async ({ ctx, input }) => {
-        const report = await ctx.env.kvDao.getReport(input);
-        await ctx.env.kvDao.removeRating(report.professorId, report.ratingId);
+        const report = await requireReport(ctx, input);
+        const professor = await requireProfessor(ctx, report.professorId);
+        if (!getProfessorRatingIds(professor).has(report.ratingId)) {
+            throw new TRPCError({
+                code: "NOT_FOUND",
+                message: `Rating with id ${report.ratingId} does not exist on professor ${report.professorId}.`,
+            });
+        }
+        await ctx.env.kvDao.removeRatingWithProfessor(professor, report.ratingId);
         await ctx.env.kvDao.removeReport(input);
     }),
     fixEscapedChars: protectedProcedure
         .input(fixEscapedCharsParser)
         .mutation(async ({ ctx, input }) => {
-            for (const profId of input.professors) {
-                // eslint-disable-next-line no-await-in-loop
-                const professor = await ctx.env.kvDao.getProfessor(profId);
+            const professors = await Promise.all(
+                input.professors.map((profId) => ctx.env.kvDao.getProfessorOptional(profId)),
+            );
+            const missingIds = input.professors.filter((_, idx) => !professors[idx]);
+            if (missingIds.length > 0) {
+                throw new TRPCError({
+                    code: "NOT_FOUND",
+                    message: `Unknown professor id(s): ${missingIds.join(", ")}`,
+                });
+            }
+
+            for (const professor of professors as Professor[]) {
                 for (const [course, ratings] of Object.entries(professor.reviews)) {
                     professor.reviews[course] = ratings.map((rating) => {
                         // eslint-disable-next-line

--- a/packages/backend/src/routers/admin.ts
+++ b/packages/backend/src/routers/admin.ts
@@ -111,6 +111,18 @@ function buildBulkDeletionAuditMessage(
     return message;
 }
 
+async function removeReportBestEffort(
+    kvDao: { removeReport(ratingId: string): Promise<void> },
+    ratingId: string,
+): Promise<void> {
+    try {
+        await kvDao.removeReport(ratingId);
+    } catch {
+        // Do not fail the primary deletion path if report cleanup fails.
+        // Cleanup can be retried by future moderation actions.
+    }
+}
+
 export const adminRouter = t.router({
     removeRating: protectedProcedure
         .input(z.object({ professorId: z.uuid(), ratingId: z.uuid() }))
@@ -123,7 +135,7 @@ export const adminRouter = t.router({
                 });
             }
             await ctx.env.kvDao.removeRatingWithProfessor(professor, ratingId);
-            await ctx.env.kvDao.removeReport(ratingId);
+            await removeReportBestEffort(ctx.env.kvDao, ratingId);
         }),
     removeRatingsBulk: protectedProcedure
         .input(
@@ -155,7 +167,7 @@ export const adminRouter = t.router({
             }
             const removed = await ctx.env.kvDao.removeRatingsBulk(professor, ratingIds);
             await Promise.all(
-                removedRatingIds.map((ratingId) => ctx.env.kvDao.removeReport(ratingId)),
+                removedRatingIds.map((ratingId) => removeReportBestEffort(ctx.env.kvDao, ratingId)),
             );
             const auditMessage = buildBulkDeletionAuditMessage(
                 ctx.user!.username,
@@ -252,15 +264,17 @@ export const adminRouter = t.router({
     }),
     actOnReport: protectedProcedure.input(z.uuid()).mutation(async ({ ctx, input }) => {
         const report = await requireReport(ctx, input);
-        const professor = await requireProfessor(ctx, report.professorId);
+        const professor = await ctx.env.kvDao.getProfessorOptional(report.professorId);
+        if (!professor) {
+            await removeReportBestEffort(ctx.env.kvDao, input);
+            return;
+        }
         if (!getProfessorRatingIds(professor).has(report.ratingId)) {
-            throw new TRPCError({
-                code: "NOT_FOUND",
-                message: `Rating with id ${report.ratingId} does not exist on professor ${report.professorId}.`,
-            });
+            await removeReportBestEffort(ctx.env.kvDao, input);
+            return;
         }
         await ctx.env.kvDao.removeRatingWithProfessor(professor, report.ratingId);
-        await ctx.env.kvDao.removeReport(input);
+        await removeReportBestEffort(ctx.env.kvDao, input);
     }),
     fixEscapedChars: protectedProcedure
         .input(fixEscapedCharsParser)

--- a/packages/backend/src/routers/auth.ts
+++ b/packages/backend/src/routers/auth.ts
@@ -1,9 +1,9 @@
 import { TRPCError } from "@trpc/server";
-import { t, protectedProcedure } from "@backend/trpc";
+import { t, protectedProcedure, publicProcedure } from "@backend/trpc";
 import { z } from "zod";
 
 export const authRouter = t.router({
-    login: t.procedure
+    login: publicProcedure
         .input(z.object({ username: z.string(), password: z.string() }))
         .mutation(async ({ input: { username, password }, ctx }) => {
             const user = await ctx.env.kvDao.getUser(username);

--- a/packages/backend/src/routers/professor.ts
+++ b/packages/backend/src/routers/professor.ts
@@ -1,23 +1,33 @@
-import { t } from "@backend/trpc";
+import { t, publicProcedure } from "@backend/trpc";
 import { z } from "zod";
-import { Professor, publicProfessorParser, ratingBaseParser } from "@backend/types/schema";
+import {
+    Professor,
+    publicProfessorParser,
+    ratingBaseParser,
+    truncatedProfessorParser,
+} from "@backend/types/schema";
 import { DEPARTMENT_LIST } from "@backend/utils/const";
 import { addRating as addRatingToProfessor } from "@backend/types/schemaHelpers";
 import { addRating } from "./rating";
 
 export const professorRouter = t.router({
-    all: t.procedure.query(({ ctx }) => ctx.env.kvDao.getAllProfessors()),
-    get: t.procedure
+    all: publicProcedure
+        .output(truncatedProfessorParser.array())
+        .query(({ ctx }) => ctx.env.kvDao.getAllProfessors()),
+    get: publicProcedure
         .input(z.object({ id: z.uuid() }))
         .output(publicProfessorParser)
         .query(({ input, ctx }) => ctx.env.kvDao.getProfessor(input.id)),
-    getMany: t.procedure
+    getMany: publicProcedure
         .input(z.object({ ids: z.uuid().array() }))
         .output(publicProfessorParser.array())
-        .query(({ input, ctx }) =>
-            Promise.all(input.ids.map((id) => ctx.env.kvDao.getProfessor(id))),
-        ),
-    add: t.procedure
+        .query(async ({ input, ctx }) => {
+            const results = await Promise.all(
+                input.ids.map((id) => ctx.env.kvDao.getProfessorOptional(id)),
+            );
+            return results.filter((p): p is Professor => p !== undefined);
+        }),
+    add: publicProcedure
         .input(
             z.object({
                 department: z.enum(DEPARTMENT_LIST),
@@ -44,7 +54,8 @@ export const professorRouter = t.router({
                     professorId: existingProfessor.id,
                     message:
                         "Your request for adding a new professor was automatically added to " +
-                        `${existingProfessor.lastName}, ${existingProfessor.firstName}. Please reach out to dev@polyratings.dev if this is incorrect`,
+                        `${existingProfessor.lastName}, ${existingProfessor.firstName}. ` +
+                        "Please reach out to dev@polyratings.dev if this is incorrect",
                 };
             }
 

--- a/packages/backend/src/routers/professor.ts
+++ b/packages/backend/src/routers/professor.ts
@@ -20,12 +20,20 @@ export const professorRouter = t.router({
         .query(({ input, ctx }) => ctx.env.kvDao.getProfessor(input.id)),
     getMany: publicProcedure
         .input(z.object({ ids: z.uuid().array() }))
-        .output(publicProfessorParser.array())
+        .output(
+            z.object({
+                professors: publicProfessorParser.array(),
+                missingIds: z.uuid().array(),
+            }),
+        )
         .query(async ({ input, ctx }) => {
             const results = await Promise.all(
                 input.ids.map((id) => ctx.env.kvDao.getProfessorOptional(id)),
             );
-            return results.filter((p): p is Professor => p !== undefined);
+            return {
+                professors: results.filter((p): p is Professor => p !== undefined),
+                missingIds: input.ids.filter((_, index) => !results[index]),
+            };
         }),
     add: publicProcedure
         .input(

--- a/packages/backend/src/routers/rating.ts
+++ b/packages/backend/src/routers/rating.ts
@@ -1,4 +1,4 @@
-import { t } from "@backend/trpc";
+import { t, publicProcedure } from "@backend/trpc";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
@@ -87,21 +87,24 @@ export async function addRating(input: z.infer<typeof addRatingParser>, ctx: { e
 }
 
 export const ratingsRouter = t.router({
-    add: t.procedure
+    add: publicProcedure
         .use(getRateLimiter("addRating"))
         .input(addRatingParser)
         .output(publicProfessorParser)
         .mutation(async ({ ctx, input }) => addRating(input, ctx)),
-    report: t.procedure
+    report: publicProcedure
         .input(reportParser.extend({ ratingId: z.uuid(), professorId: z.uuid() }))
         .mutation(async ({ ctx, input }) => {
             const anonymousIdentifier = await ctx.env.anonymousIdDao.getIdentifier();
             let professor;
             try {
                 professor = await ctx.env.kvDao.getProfessor(input.professorId);
-            } catch {
+            } catch (error) {
                 // If the professor no longer exists, treat stale report submissions as no-op.
-                return;
+                if (error instanceof TRPCError && error.code === "NOT_FOUND") {
+                    return;
+                }
+                throw error;
             }
 
             // Guard against stale client caches: if the rating no longer exists, ignore the report.
@@ -110,6 +113,7 @@ export const ratingsRouter = t.router({
                 .find((r) => r.id === input.ratingId);
 
             if (!rating) {
+                // If the rating no longer exists, ignore the report.
                 return;
             }
 

--- a/packages/backend/src/routers/rating.ts
+++ b/packages/backend/src/routers/rating.ts
@@ -95,7 +95,6 @@ export const ratingsRouter = t.router({
     report: publicProcedure
         .input(reportParser.extend({ ratingId: z.uuid(), professorId: z.uuid() }))
         .mutation(async ({ ctx, input }) => {
-            const anonymousIdentifier = await ctx.env.anonymousIdDao.getIdentifier();
             let professor;
             try {
                 professor = await ctx.env.kvDao.getProfessor(input.professorId);
@@ -116,6 +115,7 @@ export const ratingsRouter = t.router({
                 // If the rating no longer exists, ignore the report.
                 return;
             }
+            const anonymousIdentifier = await ctx.env.anonymousIdDao.getIdentifier();
 
             const ratingReport: RatingReport = {
                 ratingId: input.ratingId,

--- a/packages/backend/src/trpc.ts
+++ b/packages/backend/src/trpc.ts
@@ -10,10 +10,30 @@ type Context = {
 
 export const t = initTRPC.context<Context>().create({});
 
-export const protectedProcedure = t.procedure.use((params) => {
-    if (!params.ctx.user) {
+const normalizeUnknownErrors = t.middleware(async ({ next, path, type }) => {
+    try {
+        return await next();
+    } catch (error) {
+        if (error instanceof TRPCError) {
+            throw error;
+        }
+        throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Something went wrong. Please try again.",
+            cause:
+                error instanceof Error
+                    ? new Error(`Unhandled error in ${type} ${path}`, { cause: error })
+                    : error,
+        });
+    }
+});
+
+export const publicProcedure = t.procedure.use(normalizeUnknownErrors);
+
+export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
+    if (!ctx.user) {
         throw new TRPCError({ code: "UNAUTHORIZED" });
     }
 
-    return params.next(params);
+    return next();
 });

--- a/packages/frontend/src/pages/Admin.tsx
+++ b/packages/frontend/src/pages/Admin.tsx
@@ -42,9 +42,10 @@ export function Admin() {
 
 function ReportedRatings() {
     const { data: ratingReports } = useDbValues("reports");
-    const { data: professors } = trpc.professors.getMany.useQuery({
+    const { data: professorsResult } = trpc.professors.getMany.useQuery({
         ids: ratingReports?.map((report) => report.professorId) ?? [],
     });
+    const professors = professorsResult?.professors;
     const queryClient = useQueryClient();
     const { mutate: removeReport } = trpc.admin.removeReport.useMutation({
         onSuccess: () =>


### PR DESCRIPTION
Align backend routers on consistent tRPC error semantics and stale-id handling so admin and report flows behave predictably.