### PR TITLE
refactor(backend): unify anonymous rate limiting binding

### DIFF
--- a/packages/backend/src/env.ts
+++ b/packages/backend/src/env.ts
@@ -40,9 +40,8 @@ export class Env {
 
     anonymousIdDao: AnonymousIdDao;
 
-    rateLimiters: {
-        addRating: RateLimit;
-    };
+    /** Anonymous mutation limits use `${tRPC path}_${anonId}`; one binding is enough. */
+    rateLimiter: RateLimit;
 
     constructor(env: CloudflareEnv) {
         this.kvDao = new KVDAO(
@@ -75,9 +74,7 @@ export class Env {
 
         this.anonymousIdDao = new AnonymousIdDao(env.HASHED_IP, env.POLYRATINGS_SESSIONS);
 
-        this.rateLimiters = {
-            addRating: env.ADD_RATING_LIMITER,
-        };
+        this.rateLimiter = env.RATE_LIMITER;
     }
 }
 
@@ -100,5 +97,5 @@ const cloudflareEnvParser = z.object({
     DISCORD_WEBHOOK_URL: z.string(),
     IS_DEPLOYED: z.boolean(),
     HASHED_IP: z.string(),
-    ADD_RATING_LIMITER: rateLimiterParser,
+    RATE_LIMITER: rateLimiterParser,
 });

--- a/packages/backend/src/middleware/rate-limiter.ts
+++ b/packages/backend/src/middleware/rate-limiter.ts
@@ -7,7 +7,7 @@ import { TRPCError } from "@trpc/server";
  *
  * @throws TRPCError with code 'TOO_MANY_REQUESTS' if the rate limit is exceeded.
  */
-export const isRateLimited = t.middleware(async (opts) => {
+export const rateLimitMiddleware = t.middleware(async (opts) => {
     const { ctx, path } = opts;
 
     if (ctx.user) {
@@ -30,5 +30,5 @@ export const isRateLimited = t.middleware(async (opts) => {
     return opts.next();
 });
 
-/** Public procedure with anonymous rate limiting applied (see `isRateLimited`). */
-export const rateLimitedPublicProcedure = publicProcedure.use(isRateLimited);
+/** Public procedure with anonymous rate limiting applied (see `rateLimitMiddleware`). */
+export const rateLimitedPublicProcedure = publicProcedure.use(rateLimitMiddleware);

--- a/packages/backend/src/middleware/rate-limiter.ts
+++ b/packages/backend/src/middleware/rate-limiter.ts
@@ -1,39 +1,34 @@
-import { Env } from "@backend/env";
-import { t } from "@backend/trpc";
+import { publicProcedure, t } from "@backend/trpc";
 import { TRPCError } from "@trpc/server";
 
 /**
- * Middleware function that checks if the request is limited by rate limiting.
- * Throws an error if the rate limit is exceeded.
+ * Enforces `env.rateLimiter` with key `${tRPC path}_${anonId}` (per procedure, per anonymous client).
+ * Skips when `ctx.user` is set (admin JWT).
  *
- * @param rateLimiterName - The rate limiter to use.
- * @returns A promise that resolves to the result of the next middleware function.
  * @throws TRPCError with code 'TOO_MANY_REQUESTS' if the rate limit is exceeded.
  */
-export const getRateLimiter = (rateLimiterName: keyof Env["rateLimiters"]) =>
-    t.middleware(async (opts) => {
-        const { ctx, path } = opts;
+export const isRateLimited = t.middleware(async (opts) => {
+    const { ctx, path } = opts;
 
-        // Skip rate limiting for authenticated admins
-        if (ctx.user) {
-            return opts.next();
-        }
-
-        const anonId = await ctx.env.anonymousIdDao.getIdentifier();
-
-        // Check if the request is limited by rate limiting (uses anonId and URI)
-        const { success } = await ctx.env.rateLimiters[rateLimiterName].limit({
-            key: `${path}_${anonId}`,
-        });
-
-        if (!success) {
-            // Throw an error if the rate limit is exceeded
-            throw new TRPCError({
-                message: "Rate limit exceeded",
-                code: "TOO_MANY_REQUESTS",
-            });
-        }
-
-        // Otherwise, continue to the next middleware function
+    if (ctx.user) {
         return opts.next();
+    }
+
+    const anonId = await ctx.env.anonymousIdDao.getIdentifier();
+
+    const { success } = await ctx.env.rateLimiter.limit({
+        key: `${path}_${anonId}`,
     });
+
+    if (!success) {
+        throw new TRPCError({
+            message: "Rate limit exceeded",
+            code: "TOO_MANY_REQUESTS",
+        });
+    }
+
+    return opts.next();
+});
+
+/** Public procedure with anonymous rate limiting applied (see `isRateLimited`). */
+export const rateLimitedPublicProcedure = publicProcedure.use(isRateLimited);

--- a/packages/backend/src/routers/professor.ts
+++ b/packages/backend/src/routers/professor.ts
@@ -1,4 +1,5 @@
 import { t, publicProcedure } from "@backend/trpc";
+import { rateLimitedPublicProcedure } from "@backend/middleware/rate-limiter";
 import { z } from "zod";
 import {
     Professor,
@@ -35,7 +36,7 @@ export const professorRouter = t.router({
                 missingIds: input.ids.filter((_, index) => !results[index]),
             };
         }),
-    add: publicProcedure
+    add: rateLimitedPublicProcedure
         .input(
             z.object({
                 department: z.enum(DEPARTMENT_LIST),

--- a/packages/backend/src/routers/rating.ts
+++ b/packages/backend/src/routers/rating.ts
@@ -1,4 +1,5 @@
-import { t, publicProcedure } from "@backend/trpc";
+import { t } from "@backend/trpc";
+import { rateLimitedPublicProcedure } from "@backend/middleware/rate-limiter";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
@@ -10,7 +11,6 @@ import {
 } from "@backend/types/schema";
 import { DEPARTMENT_LIST } from "@backend/utils/const";
 import { Env } from "@backend/env";
-import { getRateLimiter } from "@backend/middleware/rate-limiter";
 import type { Moderation } from "openai/resources/moderations";
 import { checkModerationThresholds } from "@backend/utils/moderation";
 
@@ -87,12 +87,11 @@ export async function addRating(input: z.infer<typeof addRatingParser>, ctx: { e
 }
 
 export const ratingsRouter = t.router({
-    add: publicProcedure
-        .use(getRateLimiter("addRating"))
+    add: rateLimitedPublicProcedure
         .input(addRatingParser)
         .output(publicProfessorParser)
         .mutation(async ({ ctx, input }) => addRating(input, ctx)),
-    report: publicProcedure
+    report: rateLimitedPublicProcedure
         .input(reportParser.extend({ ratingId: z.uuid(), professorId: z.uuid() }))
         .mutation(async ({ ctx, input }) => {
             let professor;

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -1,3 +1,4 @@
+#:schema node_modules/wrangler/config-schema.json
 account_id = "4b59b59a6058dce1832781075d4fde9d"
 workers_dev = false
 compatibility_date = "2022-01-15"
@@ -28,11 +29,12 @@ watch_dir = [
     "src/trpc.ts",
 ]
 
-[[unsafe.bindings]]
-name = "ADD_RATING_LIMITER"
-type = "ratelimit"
+# First-class rate limits (replaces experimental `unsafe.bindings` ratelimit entries).
+# Keys are `${tRPC path}_${anonId}` in middleware, so one binding covers all public mutations.
+[[ratelimits]]
+name = "RATE_LIMITER"
 namespace_id = "1000"
-simple = { limit = 20, period = 10 } # 20 requests every 10 seconds
+simple = { limit = 20, period = 10 } # 20 requests every 10 seconds (local / default)
 
 [env.dev]
 name = 'polyratings-dev-backend'
@@ -46,9 +48,8 @@ kv_namespaces = [
     { binding = "POLYRATINGS_SESSIONS", id = "62feb12023254effb0d2b7842e74589f", preview_id = "62feb12023254effb0d2b7842e74589f" },
 ]
 
-[[env.dev.unsafe.bindings]]
-name = "ADD_RATING_LIMITER"
-type = "ratelimit"
+[[env.dev.ratelimits]]
+name = "RATE_LIMITER"
 namespace_id = "1001"
 simple = { limit = 20, period = 10 } # 20 requests every 10 seconds
 
@@ -64,9 +65,8 @@ kv_namespaces = [
     { binding = "POLYRATINGS_SESSIONS", id = "3f1960ed2db04d71ab8a560b86cee81f" },
 ]
 
-[[env.beta.unsafe.bindings]]
-name = "ADD_RATING_LIMITER"
-type = "ratelimit"
+[[env.beta.ratelimits]]
+name = "RATE_LIMITER"
 namespace_id = "1002"
 simple = { limit = 2, period = 10 } # 2 requests every 10 seconds
 
@@ -82,9 +82,8 @@ kv_namespaces = [
     { binding = "POLYRATINGS_SESSIONS", id = "d9cd467978be4b46b90d82b081b95cb9" },
 ]
 
-[[env.prod.unsafe.bindings]]
-name = "ADD_RATING_LIMITER"
-type = "ratelimit"
+[[env.prod.ratelimits]]
+name = "RATE_LIMITER"
 namespace_id = "1003"
 simple = { limit = 2, period = 60 } # 2 requests every 60 seconds
 


### PR DESCRIPTION
Replace per-procedure ADD_RATING_LIMITER unsafe bindings with a single RATE_LIMITER ratelimits entry. Middleware keys limits by tRPC path and anonymous id so one binding covers add rating, report, and pending professor flows. Professor add and rating add/report use the shared rateLimitedPublicProcedure.