### PR TITLE
fix(admin): show rating author in "Rating By" column instead of reporter

### DIFF
--- a/packages/backend/src/routers/admin.ts
+++ b/packages/backend/src/routers/admin.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { addRating } from "@backend/types/schemaHelpers";
 import { bulkKeys, DEPARTMENT_LIST } from "@backend/utils/const";
 import { TRPCError } from "@trpc/server";
-import { Professor, RatingReport } from "@backend/types/schema";
+import { Professor, professorParser, RatingReport } from "@backend/types/schema";
 
 const changeDepartmentParser = z.object({
     professorId: z.uuid(),
@@ -259,6 +259,23 @@ export const adminRouter = t.router({
         .mutation(({ ctx, input: { bulkKey, keys } }) =>
             ctx.env.kvDao.getBulkValues(bulkKey, keys),
         ),
+    getProfessors: protectedProcedure
+        .input(z.object({ ids: z.uuid().array() }))
+        .output(
+            z.object({
+                professors: professorParser.array(),
+                missingIds: z.uuid().array(),
+            }),
+        )
+        .query(async ({ input, ctx }) => {
+            const results = await Promise.all(
+                input.ids.map((id) => ctx.env.kvDao.getProfessorOptional(id)),
+            );
+            return {
+                professors: results.filter((p): p is Professor => p !== undefined),
+                missingIds: input.ids.filter((_, index) => !results[index]),
+            };
+        }),
     removeReport: protectedProcedure.input(z.uuid()).mutation(async ({ ctx, input }) => {
         await ctx.env.kvDao.removeReport(input);
     }),

--- a/packages/frontend/src/pages/Admin.tsx
+++ b/packages/frontend/src/pages/Admin.tsx
@@ -42,7 +42,7 @@ export function Admin() {
 
 function ReportedRatings() {
     const { data: ratingReports } = useDbValues("reports");
-    const { data: professorsResult } = trpc.professors.getMany.useQuery({
+    const { data: professorsResult } = trpc.admin.getProfessors.useQuery({
         ids: ratingReports?.map((report) => report.professorId) ?? [],
     });
     const professors = professorsResult?.professors;
@@ -116,7 +116,14 @@ function ReportedRatings() {
         {
             name: "Rating By",
             grow: 0.5,
-            selector: (row: RatingReport) => row.reports[0]?.anonymousIdentifier ?? "",
+            selector: (row: RatingReport) => {
+                const professor = professors?.find((p) => p?.id === row.professorId);
+                return (
+                    Object.values(professor?.reviews ?? {})
+                        .flat()
+                        .find((rating) => rating.id === row.ratingId)?.anonymousIdentifier ?? ""
+                );
+            },
         },
         {
             name: "Keep",


### PR DESCRIPTION
The admin Reported Ratings table displayed the reporter's anonymous identifier in both "Submitted By" and "Rating By", because the public professor endpoint strips per-rating anonymousIdentifier and "Rating By" fell back to the report's submitter id. Add an admin-only getProfessors endpoint that returns the full Professor shape, switch the report table to use it, and look up the original rating's anonymousIdentifier the same way the "Rating" column finds the rating text.