### PR TITLE
fix(admin): redirect unauthenticated users to /login

### DIFF
--- a/packages/frontend/src/pages/Admin.tsx
+++ b/packages/frontend/src/pages/Admin.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ExpanderComponentProps, TableProps } from "react-data-table-component";
 import { Department, DEPARTMENT_LIST } from "@backend/utils/const";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/solid";
+import { Navigate } from "react-router";
 import { useAuth } from "@/hooks";
 import { trpc } from "@/trpc";
 import { bulkInvalidationKey, useDbValues } from "@/hooks/useDbValues";
@@ -26,7 +27,10 @@ function DataTable<T>({ ...rest }: TableProps<T>) {
 
 export function Admin() {
     const { isAuthenticated } = useAuth();
-    return isAuthenticated ? (
+    if (!isAuthenticated) {
+        return <Navigate to="/login" replace />;
+    }
+    return (
         <div>
             <h1 className="text-center text-6xl font-semibold my-4">Polyratings Admin Panel</h1>
             <div className="container m-auto text-lg">
@@ -35,8 +39,6 @@ export function Admin() {
                 <ProcessedRatings />
             </div>
         </div>
-    ) : (
-        <div>In order to use the admin panel you must be authenticated</div>
     );
 }
 


### PR DESCRIPTION
## Summary
- Redirect unauthenticated visitors to `/admin` to `/login` instead of rendering a static "must be authenticated" message
- Uses `<Navigate to="/login" replace />` so the unauthenticated `/admin` entry doesn't pollute browser history; `Login.tsx` already routes back to `/admin` on successful sign-in

## Test plan
- [ ] Visit `/admin` while logged out → lands on `/login`
- [ ] Sign in from that login screen → lands on `/admin` panel
- [ ] Visit `/admin` while logged in → admin panel renders as before
- [ ] Browser back button from `/login` (after the redirect) does not return to `/admin`

https://claude.ai/code/session_012exqZ5YSZ9bZeR7B5fyxPz

---
_Generated by [Claude Code](https://claude.ai/code/session_012exqZ5YSZ9bZeR7B5fyxPz)_