### PR TITLE
Redirect unknown and missing professor routes to home

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,13 +3111,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13205,13 +13205,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13224,9 +13224,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -16971,7 +16971,7 @@
       "version": "0.0.1",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.0",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "axe-core": "^4.10.3"
       }
     },

--- a/packages/e2e/docs/Admin.md
+++ b/packages/e2e/docs/Admin.md
@@ -16,17 +16,18 @@ The admin route exposes moderation surfaces for pending professors, reported rat
 | ------- | ------------------------------------------------------------------------------------------------ | -------- |
 | ADMIN-1 | Authenticated users visiting `/admin` see "Polyratings Admin Panel" heading                      | Must     |
 | ADMIN-2 | Authenticated users see sections for Pending Professors, Reported Ratings, and Processed Ratings | Must     |
-| ADMIN-3 | Unauthenticated users visiting `/admin` see access-gated messaging                               | Must     |
+| ADMIN-3 | Unauthenticated users visiting `/admin` redirect to `/login` without admin panel content         | Must     |
 
 ## Test Scenarios
 
 | Scenario                                            | Criteria Covered    | Spec            | Status      |
 | --------------------------------------------------- | ------------------- | --------------- | ----------- |
 | Admin panel sections are visible when authenticated | ADMIN-1 and ADMIN-2 | `admin.spec.ts` | Planned     |
-| Access-gated message appears when unauthenticated   | ADMIN-3             | `admin.spec.ts` | Implemented |
+| Unauthenticated visit redirects to login          | ADMIN-3             | `admin.spec.ts` | Implemented |
 
 ## Implementation
 
 - **Spec file:** `packages/e2e/src/admin.spec.ts`
-- **Implemented tests:** `ADMIN: access-gated message appears when unauthenticated`
+- **Implemented tests:** `ADMIN: unauthenticated users redirect to login`
+- **Frontend route handling:** `packages/frontend/src/pages/Admin.tsx` redirects unauthenticated users with `<Navigate to="/login" replace />`
 - **Status:** Partially implemented

--- a/packages/e2e/docs/NotFound.md
+++ b/packages/e2e/docs/NotFound.md
@@ -1,0 +1,37 @@
+# Not Found Redirect – Business Requirements
+
+## Feature
+
+Unknown routes and missing professor pages redirect users back to the home route instead of showing a generic application error. Desktop users see a brief toast; mobile users see an interim message with a 3-second countdown before redirect.
+
+## User Stories
+
+- As a student, I want mistyped URLs to send me back to Polyratings so I can recover quickly.
+- As a student, I want stale or invalid professor links to explain that the professor was not found before returning me home.
+- As a mobile user, I want enough time to read why I am being redirected before the navigation happens.
+
+## Acceptance Criteria
+
+| ID          | Criterion                                                                                         | Priority |
+| ----------- | ------------------------------------------------------------------------------------------------- | -------- |
+| NOT-FOUND-1 | Navigating to an unknown path on desktop redirects to `/` and shows the home page                 | Must     |
+| NOT-FOUND-2 | Navigating to an unknown path on mobile shows a countdown, then redirects to `/`                 | Must     |
+| NOT-FOUND-3 | Navigating to an invalid professor id on desktop redirects to `/` and shows the home page         | Must     |
+| NOT-FOUND-4 | Navigating to an invalid professor id on mobile shows a professor-not-found countdown, then `/`    | Must     |
+
+## Test Scenarios
+
+| Scenario                                              | Criteria Covered           | Spec                          | Status      |
+| ----------------------------------------------------- | -------------------------- | ----------------------------- | ----------- |
+| Unknown route redirects immediately on desktop        | NOT-FOUND-1                | `not-found-redirect.spec.ts`  | Implemented |
+| Unknown route shows countdown then redirects on mobile | NOT-FOUND-2                | `not-found-redirect.spec.ts`  | Implemented |
+| Invalid professor id redirects immediately on desktop | NOT-FOUND-3                | `not-found-redirect.spec.ts`  | Implemented |
+| Invalid professor id shows countdown on mobile        | NOT-FOUND-4                | `not-found-redirect.spec.ts`  | Implemented |
+
+## Implementation
+
+- **Spec file:** `packages/e2e/src/not-found-redirect.spec.ts`
+- **Frontend route handling:** `packages/frontend/src/pages/NotFoundRedirect.tsx`, catch-all route and professor loader in `packages/frontend/src/App.tsx` and `packages/frontend/src/pages/ProfessorPage.tsx`
+- **Professor loader behavior:** invalid UUIDs and tRPC `NOT_FOUND` responses render the professor variant; other loader failures propagate to the router error surface.
+- **Desktop copy:** toast + immediate redirect via `<Navigate replace to="/" />`.
+- **Mobile copy:** heading plus visual countdown; screen readers get a single static redirect announcement (no per-second `aria-live` updates).

--- a/packages/e2e/docs/README.md
+++ b/packages/e2e/docs/README.md
@@ -32,6 +32,7 @@ Per-test customization uses `scanForA11yViolations((builder) => ...)` or builds 
 | [Search.md](./Search.md)                           | Search no-results fallback flow                                    | `src/search.spec.ts`             | Implemented           |
 | [PublicAccessibility.md](./PublicAccessibility.md) | WCAG scan baseline for public routes                               | `src/a11y/public-routes.spec.ts` | Implemented           |
 | [ProfessorPage.md](./ProfessorPage.md)             | Professor profile, ratings visibility, and evaluation entry points | `src/professor-page.spec.ts`     | Partially implemented |
+| [NotFound.md](./NotFound.md)                       | Unknown routes and missing professors redirect home                | `src/not-found-redirect.spec.ts` | Implemented           |
 | [NewProfessor.md](./NewProfessor.md)               | Add-a-professor submission flow                                    | `src/new-professor.spec.ts`      | Implemented           |
 | [Login.md](./Login.md)                             | Admin login form and redirect behavior                             | `src/login.spec.ts`              | Partially implemented |
 | [Admin.md](./Admin.md)                             | Admin panel access and moderation surfaces                         | `src/admin.spec.ts`              | Partially implemented |

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -12,7 +12,7 @@
     },
     "devDependencies": {
         "@axe-core/playwright": "^4.11.0",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "axe-core": "^4.10.3"
     }
 }

--- a/packages/e2e/src/admin.spec.ts
+++ b/packages/e2e/src/admin.spec.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-test("ADMIN: access-gated message appears when unauthenticated", async ({ page }) => {
+test("ADMIN: unauthenticated users redirect to login", async ({ page }) => {
     await page.goto("/admin");
 
-    await test.step("ADMIN-3: unauthenticated users see access-gated messaging", async () => {
-        await expect(
-            page.getByText("In order to use the admin panel you must be authenticated"),
-        ).toBeVisible();
+    await test.step("ADMIN-3: unauthenticated users are sent to sign in", async () => {
+        await expect(page).toHaveURL(/\/login$/);
+        await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
         await expect(
             page.getByRole("heading", { name: "Polyratings Admin Panel" }),
         ).not.toBeVisible();

--- a/packages/e2e/src/not-found-redirect.spec.ts
+++ b/packages/e2e/src/not-found-redirect.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
+const MOBILE_VIEWPORT = { width: 375, height: 812 };
+
+test.describe("NOT-FOUND: redirect unknown routes to home", () => {
+    test("NOT-FOUND-1: unknown route redirects immediately on desktop", async ({ page }) => {
+        await page.setViewportSize(DESKTOP_VIEWPORT);
+        await page.goto("/nothing-to-see-here");
+
+        await expect(page).toHaveURL("/");
+        await expect(page.getByRole("heading", { name: "Polyratings" })).toBeVisible();
+    });
+
+    test("NOT-FOUND-2: unknown route shows countdown then redirects on mobile", async ({ page }) => {
+        await page.setViewportSize(MOBILE_VIEWPORT);
+        await page.goto("/nothing-to-see-here");
+
+        await expect(page.getByRole("heading", { name: "Page not found" })).toBeVisible();
+        await expect(page.getByText("We'll redirect you to the home page in")).toBeVisible();
+        await expect(page).toHaveURL("/", { timeout: 5000 });
+        await expect(page.getByRole("heading", { name: "Polyratings" })).toBeVisible();
+    });
+});
+
+test.describe("NOT-FOUND: redirect invalid professor routes to home", () => {
+    test("NOT-FOUND-3: invalid professor id redirects immediately on desktop", async ({ page }) => {
+        await page.setViewportSize(DESKTOP_VIEWPORT);
+        await page.goto("/professor/not-a-real-id");
+
+        await expect(page).toHaveURL("/");
+        await expect(page.getByRole("heading", { name: "Polyratings" })).toBeVisible();
+    });
+
+    test("NOT-FOUND-4: invalid professor id shows countdown then redirects on mobile", async ({
+        page,
+    }) => {
+        await page.setViewportSize(MOBILE_VIEWPORT);
+        await page.goto("/professor/not-a-real-id");
+
+        await expect(page.getByRole("heading", { name: "Professor not found" })).toBeVisible();
+        await expect(page.getByText("We'll redirect you to the home page in")).toBeVisible();
+        await expect(page).toHaveURL("/", { timeout: 5000 });
+        await expect(page.getByRole("heading", { name: "Polyratings" })).toBeVisible();
+    });
+});

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -12,12 +12,13 @@ import { persistQueryClient } from "@tanstack/react-query-persist-client";
 import { useMemo, useState } from "react";
 import {
     Home,
-    ProfessorPage,
+    ProfessorPageRoute,
     Login,
     NewProfessor,
     About,
     Admin,
     FAQ,
+    NotFoundRedirect,
     professorPageLoaderFactory,
     SearchWrapper,
 } from "./pages";
@@ -84,23 +85,28 @@ export default function App() {
 function PolyratingsRouter() {
     const trpcContext = trpc.useUtils();
 
-    const router = createBrowserRouter(
-        createRoutesFromElements(
-            <Route path="/" element={<BaseComponent />}>
-                <Route index element={<Home />} />
-                <Route
-                    path="professor/:id"
-                    element={<ProfessorPage />}
-                    loader={professorPageLoaderFactory(trpcContext)}
-                />
-                <Route path="search/:searchType" element={<SearchWrapper />} />
-                <Route path="login" element={<Login />} />
-                <Route path="new-professor" element={<NewProfessor />} />
-                <Route path="about" element={<About />} />
-                <Route path="admin" element={<Admin />} />
-                <Route path="faq" element={<FAQ />} />
-            </Route>,
-        ),
+    const router = useMemo(
+        () =>
+            createBrowserRouter(
+                createRoutesFromElements(
+                    <Route path="/" element={<BaseComponent />}>
+                        <Route index element={<Home />} />
+                        <Route
+                            path="professor/:id"
+                            element={<ProfessorPageRoute />}
+                            loader={professorPageLoaderFactory(trpcContext)}
+                        />
+                        <Route path="search/:searchType" element={<SearchWrapper />} />
+                        <Route path="login" element={<Login />} />
+                        <Route path="new-professor" element={<NewProfessor />} />
+                        <Route path="about" element={<About />} />
+                        <Route path="admin" element={<Admin />} />
+                        <Route path="faq" element={<FAQ />} />
+                        <Route path="*" element={<NotFoundRedirect />} />
+                    </Route>,
+                ),
+            ),
+        [trpcContext],
     );
 
     return <RouterProvider router={router} />;
@@ -110,7 +116,7 @@ function BaseComponent() {
     return (
         <>
             <ScrollRestoration />
-            <ToastContainer />
+            <ToastContainer pauseOnFocusLoss={false} pauseOnHover={false} />
             <Navbar />
             <Outlet />
         </>

--- a/packages/frontend/src/pages/NotFoundRedirect.tsx
+++ b/packages/frontend/src/pages/NotFoundRedirect.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router";
+import { toast } from "react-toastify";
+
+const REDIRECT_DELAY_SECONDS = 3;
+const MOBILE_MEDIA_QUERY = "(max-width: 767px)";
+
+type NotFoundRedirectVariant = "page" | "professor";
+
+const MESSAGES: Record<NotFoundRedirectVariant, { title: string; toast: string }> = {
+    page: {
+        title: "Page not found",
+        toast: "Page not found. Returning to the home page.",
+    },
+    professor: {
+        title: "Professor not found",
+        toast: "Professor not found. Returning to the home page.",
+    },
+};
+
+function getIsMobileViewport() {
+    return window.matchMedia(MOBILE_MEDIA_QUERY).matches;
+}
+
+interface NotFoundRedirectProps {
+    variant?: NotFoundRedirectVariant;
+}
+
+export function NotFoundRedirect({ variant = "page" }: NotFoundRedirectProps) {
+    const { title, toast: toastMessage } = MESSAGES[variant];
+    const [isMobile, setIsMobile] = useState(getIsMobileViewport);
+    const [secondsRemaining, setSecondsRemaining] = useState(REDIRECT_DELAY_SECONDS);
+    const [shouldRedirectHome, setShouldRedirectHome] = useState(() => !getIsMobileViewport());
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia(MOBILE_MEDIA_QUERY);
+        const handleChange = () => setIsMobile(mediaQuery.matches);
+        mediaQuery.addEventListener("change", handleChange);
+        return () => mediaQuery.removeEventListener("change", handleChange);
+    }, []);
+
+    useEffect(() => {
+        if (!isMobile) {
+            toast.info(toastMessage);
+        }
+    }, [isMobile, toastMessage]);
+
+    useEffect(() => {
+        if (!isMobile) {
+            return undefined;
+        }
+
+        const tickInterval = window.setInterval(() => {
+            setSecondsRemaining((current) => Math.max(current - 1, 0));
+        }, 1000);
+
+        const redirectTimeout = window.setTimeout(() => {
+            setShouldRedirectHome(true);
+        }, REDIRECT_DELAY_SECONDS * 1000);
+
+        return () => {
+            window.clearInterval(tickInterval);
+            window.clearTimeout(redirectTimeout);
+        };
+    }, [isMobile]);
+
+    if (shouldRedirectHome) {
+        return <Navigate to="/" replace />;
+    }
+
+    return (
+        <main className="flex flex-col items-center justify-center min-h-screen-wo-nav px-6 text-center">
+            <h1 className="text-4xl font-semibold text-cal-poly-green mb-4">{title}</h1>
+            <p className="sr-only">
+                We will redirect you to the home page in {REDIRECT_DELAY_SECONDS} seconds.
+            </p>
+            <p className="text-lg text-gray-700">
+                We&apos;ll redirect you to the home page in {secondsRemaining}{" "}
+                {secondsRemaining === 1 ? "second" : "seconds"}.
+            </p>
+        </main>
+    );
+}

--- a/packages/frontend/src/pages/ProfessorPage.tsx
+++ b/packages/frontend/src/pages/ProfessorPage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { type ChangeEvent, Fragment, type FormEvent, useEffect, useState } from "react";
-import { IndexRouteObject, useNavigate, useParams } from "react-router";
+import { IndexRouteObject, useLoaderData, useNavigate, useParams } from "react-router";
 import AnimateHeight from "react-animate-height";
 import AnchorLink from "react-anchor-link-smooth-scroll";
 import StarRatings from "react-star-ratings";
@@ -10,6 +10,7 @@ import { FlagIcon, LockClosedIcon, LockOpenIcon } from "@heroicons/react/24/outl
 import { z } from "zod";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "react-toastify";
+import { TRPCClientError } from "@trpc/client";
 import { inferProcedureOutput } from "@trpc/server";
 import { AppRouter } from "@backend/index";
 import { InView } from "react-intersection-observer";
@@ -24,13 +25,45 @@ import { trpc } from "@/trpc";
 import { REACT_MODAL_STYLES } from "@/constants";
 import { Button } from "@/components/forms/Button";
 import { useAuth, useSortedCourses } from "@/hooks";
+import { NotFoundRedirect } from "./NotFoundRedirect";
 
 type ValueOf<T> = T[keyof T];
 
+type ProfessorPageLoaderData = { notFound: true } | { notFound: false };
+
+function isProfessorNotFoundError(error: unknown): boolean {
+    return error instanceof TRPCClientError && error.data?.code === "NOT_FOUND";
+}
+
+export function ProfessorPageRoute() {
+    const loaderData = useLoaderData() as ProfessorPageLoaderData;
+
+    if (loaderData.notFound) {
+        return <NotFoundRedirect variant="professor" />;
+    }
+
+    return <ProfessorPage />;
+}
+
 export function professorPageLoaderFactory(trpcContext: ReturnType<(typeof trpc)["useUtils"]>) {
-    const professorPageLoader: IndexRouteObject["loader"] = ({ params }) =>
-        trpcContext.professors.get.getData({ id: params.id ?? "" }) ??
-        trpcContext.professors.get.fetch({ id: params.id ?? "" });
+    const professorPageLoader: IndexRouteObject["loader"] = async ({ params }) => {
+        const id = params.id ?? "";
+
+        if (!z.uuid().safeParse(id).success) {
+            return { notFound: true } satisfies ProfessorPageLoaderData;
+        }
+
+        try {
+            await (trpcContext.professors.get.getData({ id }) ??
+                trpcContext.professors.get.fetch({ id }));
+            return { notFound: false } satisfies ProfessorPageLoaderData;
+        } catch (error) {
+            if (isProfessorNotFoundError(error)) {
+                return { notFound: true } satisfies ProfessorPageLoaderData;
+            }
+            throw error;
+        }
+    };
 
     return professorPageLoader;
 }

--- a/packages/frontend/src/pages/index.ts
+++ b/packages/frontend/src/pages/index.ts
@@ -6,3 +6,4 @@ export * from "./ProfessorPage";
 export * from "./About";
 export * from "./Admin";
 export * from "./FAQ";
+export * from "./NotFoundRedirect";


### PR DESCRIPTION
Add NotFoundRedirect for catch-all and professor loader failures, bump Playwright to 1.60, and disable toast pause on hover/focus loss.

Fix e2e test which was broken after unauth'd admin redirect improvement was pushed.