### PR TITLE
Filter Safari spurious unhandled rejections in Sentry.

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -28,30 +28,6 @@ import { trpc, trpcClientOptions } from "./trpc";
 import { createIDBPersister } from "./utils/idbPersister";
 import { AuthContext, useAuthState } from "./hooks";
 
-// Lazy load error logger to save bundle size
-if (process.env.NODE_ENV === "production") {
-    const captureError = async (error: unknown) => {
-        try {
-            // eslint-disable-next-line no-console
-            console.error(error); // Log error to console for clarification
-            const Sentry = await import("@sentry/browser");
-            Sentry.init({
-                dsn: "https://c9fe8d8e92a04bb585b15499bff924c5@o1195960.ingest.sentry.io/6319109",
-                // 20% of transactions get sent to Sentry
-                tracesSampleRate: 0.2,
-            });
-            Sentry.captureException(error);
-        } catch (e) {
-            // all fails, reset window.onerror to prevent infinite loop on window.onerror
-            // eslint-disable-next-line no-console
-            console.error("Logging to Sentry failed", e);
-            window.onerror = null;
-        }
-    };
-    window.onerror = (message, url, line, column, error) => captureError(error);
-    window.onunhandledrejection = (event) => captureError(event.reason);
-}
-
 // TODO: Fix large screen size
 export default function App() {
     const authState = useAuthState();

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -3,6 +3,11 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import Modal from "react-modal";
 import App from "./App";
+import { initSentry } from "./sentry";
+
+if (process.env.NODE_ENV === "production") {
+    initSentry();
+}
 
 Modal.setAppElement("#root");
 

--- a/packages/frontend/src/sentry.spec.ts
+++ b/packages/frontend/src/sentry.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { isSpuriousUnhandledRejectionNoise } from "./sentry";
+
+describe("isSpuriousUnhandledRejectionNoise", () => {
+    test("filters undefined rejections", () => {
+        expect(isSpuriousUnhandledRejectionNoise(undefined)).toBe(true);
+    });
+
+    test("filters null rejections", () => {
+        expect(isSpuriousUnhandledRejectionNoise(null)).toBe(true);
+    });
+
+    test("filters CustomEvent unhandledrejection with null detail", () => {
+        const event = new CustomEvent("unhandledrejection");
+
+        expect(isSpuriousUnhandledRejectionNoise(event)).toBe(true);
+    });
+
+    test("does not filter real Error rejections", () => {
+        expect(isSpuriousUnhandledRejectionNoise(new Error("something failed"))).toBe(false);
+    });
+
+    test("does not filter CustomEvent unhandledrejection with nested Error detail", () => {
+        const event = new CustomEvent("unhandledrejection", {
+            detail: { reason: new Error("x") },
+        });
+
+        expect(isSpuriousUnhandledRejectionNoise(event)).toBe(false);
+    });
+
+    test("does not filter unrelated CustomEvent types", () => {
+        const event = new CustomEvent("click");
+
+        expect(isSpuriousUnhandledRejectionNoise(event)).toBe(false);
+    });
+
+    test("does not filter string rejections", () => {
+        expect(isSpuriousUnhandledRejectionNoise("something went wrong")).toBe(false);
+    });
+});

--- a/packages/frontend/src/sentry.ts
+++ b/packages/frontend/src/sentry.ts
@@ -1,0 +1,38 @@
+import * as Sentry from "@sentry/browser";
+
+const SENTRY_DSN = "https://c9fe8d8e92a04bb585b15499bff924c5@o1195960.ingest.sentry.io/6319109";
+
+export function isSpuriousUnhandledRejectionNoise(reason: unknown): boolean {
+    if (reason === undefined || reason === null) {
+        return true;
+    }
+
+    if (!(reason instanceof CustomEvent) || reason.type !== "unhandledrejection") {
+        return false;
+    }
+
+    if (reason.detail == null) {
+        return true;
+    }
+
+    const nestedReason =
+        typeof reason.detail === "object" && reason.detail !== null && "reason" in reason.detail
+            ? (reason.detail as { reason?: unknown }).reason
+            : undefined;
+
+    return !(nestedReason instanceof Error);
+}
+
+export function initSentry(): void {
+    Sentry.init({
+        dsn: SENTRY_DSN,
+        tracesSampleRate: 0.2,
+        beforeSend(event, hint) {
+            if (isSpuriousUnhandledRejectionNoise(hint.originalException)) {
+                return null;
+            }
+
+            return event;
+        },
+    });
+}


### PR DESCRIPTION
Initialize Sentry once at startup, remove duplicate global handlers, and drop undefined/null/CustomEvent noise in beforeSend.

We get about 5k events per month with unactionable Sentry errors from Safari browsers, this should clean them up.

Fixes POLYRATINGS-FRONTEND-84
Fixes POLYRATINGS-FRONTEND-3Y