### PR TITLE
chore: remove fixEscapedChars after prod backfill

### DIFF
--- a/packages/backend/src/dao/kv-dao.ts
+++ b/packages/backend/src/dao/kv-dao.ts
@@ -1,5 +1,5 @@
 import { ALL_PROFESSOR_KEY, BulkKey, BulkKeyMap } from "@backend/utils/const";
-import { chunkArray, mapInBatches } from "@backend/utils/chunkArray";
+import { mapInBatches } from "@backend/utils/chunkArray";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
@@ -25,10 +25,8 @@ import { KvWrapper } from "./kv-wrapper";
 const KV_REQUESTS_PER_TRIGGER = 1000;
 const THREE_WEEKS_SECONDS = 60 * 60 * 24 * 7 * 3;
 
-// Batch processing constants for performance optimization.
-// Windows of this size are awaited before the next window starts to avoid KV 503s.
+// Window size for bulk KV reads. Awaited before the next window starts.
 const BULK_FETCH_CONCURRENCY = 50;
-const INDIVIDUAL_WRITE_CONCURRENCY = 10;
 
 export class KVDAO {
     constructor(
@@ -60,81 +58,6 @@ export class KVDAO {
             ALL_PROFESSOR_KEY,
             professorList,
         );
-    }
-
-    /**
-     * Batch update professors to reduce write amplification.
-     * Updates multiple professors with a single read and write of the professor list.
-     *
-     * WARNING: This method is not thread-safe. Concurrent calls to this method
-     * can result in lost updates due to race conditions (read-modify-write pattern).
-     * Ensure only one batch update runs at a time, or use a queue/sequencer.
-     *
-     * Cloudflare KV does not support transactions, so true atomicity is not possible.
-     * Per-id records are written first (same order as `putProfessor`); the master
-     * list is only written if every individual write succeeds. If another process
-     * modifies the list concurrently, one update may still be lost.
-     *
-     * TODO: Migrate professor storage to D1 so list + record updates can run in a
-     * single SQL transaction instead of this KV read-modify-write.
-     */
-    async batchUpdateProfessors(
-        updates: Array<{ id: string; professor?: Professor; deleted?: boolean }>,
-    ): Promise<void> {
-        if (updates.length === 0) {
-            return;
-        }
-
-        // Read professor list fresh each time to minimize race condition window
-        const profList = await this.getAllProfessors();
-
-        // Collect write thunks so KV I/O does not start until we finish planning.
-        const individualWrites: Array<() => Promise<void>> = [];
-
-        for (const update of updates) {
-            if (update.deleted) {
-                const professorIndex = profList.findIndex((t) => t.id === update.id);
-                if (professorIndex !== -1) {
-                    profList.splice(professorIndex, 1);
-                }
-                individualWrites.push(async () => {
-                    await this.polyratingsNamespace.delete(update.id);
-                });
-            } else if (update.professor) {
-                const { professor } = update;
-                individualWrites.push(async () => {
-                    await this.polyratingsNamespace.put(professorParser, professor.id, professor);
-                });
-
-                const professorIndex = profList.findIndex((t) => t.id === professor.id);
-                const truncatedProf = professorToTruncatedProfessor(professor);
-
-                if (professorIndex === -1) {
-                    profList.push(truncatedProf);
-                } else {
-                    profList[professorIndex] = truncatedProf;
-                }
-            }
-        }
-
-        const writeResults: PromiseSettledResult<void>[] = [];
-        for (const batch of chunkArray(individualWrites, INDIVIDUAL_WRITE_CONCURRENCY)) {
-            // eslint-disable-next-line no-await-in-loop -- windows must complete before the next starts
-            writeResults.push(...(await Promise.allSettled(batch.map((write) => write()))));
-        }
-
-        const failedWrites = writeResults.filter(
-            (result): result is PromiseRejectedResult => result.status === "rejected",
-        );
-        if (failedWrites.length > 0) {
-            throw new TRPCError({
-                code: "INTERNAL_SERVER_ERROR",
-                message: `Failed to persist ${failedWrites.length} of ${individualWrites.length} professor record(s). Master list was not updated.`,
-                cause: failedWrites[0].reason,
-            });
-        }
-
-        await this.putAllProfessors(profList);
     }
 
     getProfessor(id: string) {

--- a/packages/backend/src/routers/admin.ts
+++ b/packages/backend/src/routers/admin.ts
@@ -28,13 +28,6 @@ const lockProfessorParser = z.object({
     lockedMessage: z.string().optional(),
 });
 
-const fixEscapedCharsParser = z.object({
-    professors: z
-        .array(z.uuid())
-        .min(1)
-        .max(250, "Separate your request into batches of 250 professors."),
-});
-
 const MAX_REASON_LENGTH = 600;
 
 function getProfessorRatingIds(professor: Professor): Set<string> {
@@ -314,77 +307,4 @@ export const adminRouter = t.router({
         await ctx.env.kvDao.removeRatingWithProfessor(professor, report.ratingId);
         await removeReportBestEffort(ctx.env.kvDao, input);
     }),
-    fixEscapedChars: protectedProcedure
-        .input(fixEscapedCharsParser)
-        .output(
-            z.object({
-                updated: z.uuid().array(),
-                skipped: z.uuid().array(),
-                failed: z.array(z.object({ profId: z.uuid(), message: z.string() })),
-            }),
-        )
-        .mutation(async ({ ctx, input }) => {
-            const professors = await Promise.all(
-                input.professors.map((profId) => ctx.env.kvDao.getProfessorOptional(profId)),
-            );
-            const missingIds = input.professors.filter((_, idx) => !professors[idx]);
-            if (missingIds.length > 0) {
-                throw new TRPCError({
-                    code: "NOT_FOUND",
-                    message: `Unknown professor id(s): ${missingIds.join(", ")}`,
-                });
-            }
-
-            const updates: Array<{ id: string; professor: Professor }> = [];
-            const skipped: string[] = [];
-            const failed: Array<{ profId: string; message: string }> = [];
-
-            (professors as Professor[]).forEach((professor, i) => {
-                const profId = input.professors[i];
-                try {
-                    let hasChanges = false;
-
-                    const processRatings = (ratings: (typeof professor.reviews)[string]) =>
-                        ratings.map((rating) => {
-                            const originalRating = rating.rating;
-                            const fixedRating = rating.rating
-                                .replaceAll("\\'", "'")
-                                // eslint-disable-next-line
-                                .replaceAll('\\"', '"');
-                            if (originalRating !== fixedRating) {
-                                hasChanges = true;
-                            }
-                            return { ...rating, rating: fixedRating };
-                        });
-
-                    for (const [course, ratings] of Object.entries(professor.reviews)) {
-                        professor.reviews[course] = processRatings(ratings);
-                    }
-
-                    if (hasChanges) {
-                        updates.push({ id: profId, professor });
-                    } else {
-                        skipped.push(profId);
-                    }
-                } catch (error) {
-                    failed.push({
-                        profId,
-                        message:
-                            error instanceof Error ? error.message : "Failed to process professor",
-                    });
-                }
-            });
-
-            if (updates.length > 0) {
-                await ctx.env.kvDao.batchUpdateProfessors(
-                    updates.map((u) => ({ id: u.id, professor: u.professor })),
-                );
-            }
-
-            return {
-                updated: updates.map((u) => u.id),
-                skipped,
-                failed,
-            };
-        }),
 });


### PR DESCRIPTION
## Summary
- Prod and beta backfills already cleaned leftover `\'` / `\"` in legacy ratings (~541 professors).
- Remove `admin.fixEscapedChars` and `KVDAO.batchUpdateProfessors`, which only existed for that one-shot job.

## Test plan
- [ ] Admin panel still loads (reports, pending professors, submit-under).
- [ ] Search and professor pages still load (bulk KV fetch path is unchanged).
- [ ] Calling `admin.fixEscapedChars` should 404 / unknown procedure.


Made with [Cursor](https://cursor.com)