### PR TITLE
Accept 4-digit semester course numbers for Fall 2026

### DIFF
--- a/packages/backend/src/dao/kv-dao.ts
+++ b/packages/backend/src/dao/kv-dao.ts
@@ -1,4 +1,5 @@
 import { ALL_PROFESSOR_KEY, BulkKey, BulkKeyMap } from "@backend/utils/const";
+import { courseReviewsKey } from "@backend/utils/courseNum";
 import { mapInBatches } from "@backend/utils/chunkArray";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
@@ -230,7 +231,7 @@ export class KVDAO {
         addRatingToProfessor(
             professor,
             newRating,
-            `${newRating.department} ${newRating.courseNum}`,
+            courseReviewsKey(newRating.department, newRating.courseNum),
         );
 
         return this.putProfessor(professor);

--- a/packages/backend/src/routers/professor.ts
+++ b/packages/backend/src/routers/professor.ts
@@ -8,6 +8,7 @@ import {
     truncatedProfessorParser,
 } from "@backend/types/schema";
 import { DEPARTMENT_LIST } from "@backend/utils/const";
+import { courseNumParser, courseReviewsKey } from "@backend/utils/courseNum";
 import { addRating as addRatingToProfessor } from "@backend/types/schemaHelpers";
 import { pendingProfessorNotification } from "@backend/utils/discordNotifications";
 import { addRating } from "./rating";
@@ -45,7 +46,7 @@ export const professorRouter = t.router({
                 lastName: z.string(),
                 rating: ratingBaseParser.extend({
                     department: z.enum(DEPARTMENT_LIST),
-                    courseNum: z.number().min(100).max(599),
+                    courseNum: courseNumParser,
                 }),
             }),
         )
@@ -84,7 +85,7 @@ export const professorRouter = t.router({
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 tags: tags as any,
                 reviews: {
-                    [`${input.rating.department} ${input.rating.courseNum}`]: [
+                    [courseReviewsKey(input.rating.department, input.rating.courseNum)]: [
                         {
                             professor: professorId,
                             id: crypto.randomUUID(),

--- a/packages/backend/src/routers/rating.ts
+++ b/packages/backend/src/routers/rating.ts
@@ -10,6 +10,7 @@ import {
     reportParser,
 } from "@backend/types/schema";
 import { DEPARTMENT_LIST } from "@backend/utils/const";
+import { courseNumParser } from "@backend/utils/courseNum";
 import { Env } from "@backend/env";
 import type { Moderation } from "openai/resources/moderations";
 import { checkModerationThresholds } from "@backend/utils/moderation";
@@ -22,7 +23,7 @@ import {
 const addRatingParser = ratingBaseParser.extend({
     professor: z.uuid(),
     department: z.enum(DEPARTMENT_LIST),
-    courseNum: z.number().min(100).max(599),
+    courseNum: courseNumParser,
 });
 
 export async function addRating(input: z.infer<typeof addRatingParser>, ctx: { env: Env }) {

--- a/packages/backend/src/types/schema.ts
+++ b/packages/backend/src/types/schema.ts
@@ -8,6 +8,7 @@ import {
     PENDING_RATING_STATUSES,
     PROFESSOR_TAGS,
 } from "@backend/utils/const";
+import { courseNumParser } from "@backend/utils/courseNum";
 import type { Moderation } from "openai/resources/moderations";
 
 export const ratingBaseParser = z.object({
@@ -40,7 +41,7 @@ export const pendingRatingParser = ratingParser.extend({
             (mod) => typeof mod === "object",
         )
         .nullable(),
-    courseNum: z.number().min(100).max(599),
+    courseNum: courseNumParser,
     department: z.enum(DEPARTMENT_LIST),
 });
 export type PendingRating = z.infer<typeof pendingRatingParser>;

--- a/packages/backend/src/utils/const.ts
+++ b/packages/backend/src/utils/const.ts
@@ -1,7 +1,9 @@
 import { PendingRating, Professor, RatingReport, User } from "@backend/types/schema";
 
 /**
- * List of all departments with courses as of 1/23/2022
+ * Department codes for professor home department and the department half of a
+ * course key (`CSC 101`). Historical 2022 codes are kept; 2026–28 SLO catalog
+ * departments/prefixes that were missing are added.
  */
 export const DEPARTMENT_LIST = [
     "AEPS",
@@ -17,6 +19,7 @@ export const DEPARTMENT_LIST = [
     "ART",
     "ASCI",
     "ASTR",
+    "ATHL",
     "BIO",
     "BMED",
     "BOT",
@@ -26,6 +29,8 @@ export const DEPARTMENT_LIST = [
     "CE",
     "CHEM",
     "CHIN",
+    "CI",
+    "CLA",
     "CM",
     "CMAT",
     "COMS",
@@ -44,13 +49,17 @@ export const DEPARTMENT_LIST = [
     "EDES",
     "EDUC",
     "EE",
+    "EIM",
+    "ELAP",
     "ENGL",
     "ENGR",
     "ENVE",
     "ERSC",
     "ES",
     "ESCI",
+    "ESM",
     "EXSS",
+    "FDSC",
     "FPE",
     "FR",
     "FSN",
@@ -63,6 +72,7 @@ export const DEPARTMENT_LIST = [
     "GSB",
     "GSE",
     "GSP",
+    "HCSA",
     "HIST",
     "HLTH",
     "HNRC",
@@ -88,10 +98,12 @@ export const DEPARTMENT_LIST = [
     "MU",
     "NE",
     "NR",
+    "NUTR",
     "PEM",
     "PEW",
     "PHIL",
     "PHYS",
+    "PLSC",
     "POLS",
     "PSC",
     "PSY",
@@ -106,6 +118,7 @@ export const DEPARTMENT_LIST = [
     "TH",
     "UNIV",
     "WGS",
+    "WGQS",
     "WLC",
     "WVIT",
 ] as const;

--- a/packages/backend/src/utils/courseNum.ts
+++ b/packages/backend/src/utils/courseNum.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const COURSE_NUM_ERROR =
+    "Use a 3-digit quarter number (100–599) or a 4-digit semester number (1000–5999)";
+
+export const COURSE_NUM_HINT =
+    "Quarter courses are 3 digits (101); Fall 2026+ courses are 4 digits (1101).";
+
+/** Quarter 100–599 or semester 1000–5999. Rejects 600–999, pre-baccalaureate, and CEU ranges. */
+export const courseNumParser = z
+    .number()
+    .int()
+    .refine((n) => (n >= 100 && n <= 599) || (n >= 1000 && n <= 5999), {
+        error: COURSE_NUM_ERROR,
+    });
+
+export function courseReviewsKey(department: string, courseNum: number): string {
+    return `${department} ${courseNum}`;
+}

--- a/packages/e2e/docs/FAQ.md
+++ b/packages/e2e/docs/FAQ.md
@@ -2,7 +2,7 @@
 
 ## Feature
 
-The FAQ route answers common questions about rating authenticity, moderation standards, and contribution channels.
+The FAQ route answers common questions about rating authenticity, moderation standards, semester course numbers, and contribution channels.
 
 ## User Stories
 
@@ -13,15 +13,16 @@ The FAQ route answers common questions about rating authenticity, moderation sta
 | ID    | Criterion                                                                  | Priority |
 | ----- | -------------------------------------------------------------------------- | -------- |
 | FAQ-1 | Navigating to `/faq` renders the main heading "Frequently Asked Questions" | Must     |
+| FAQ-2 | The FAQ explains how to rate Fall 2026+ 4-digit semester courses           | Must     |
 
 ## Test Scenarios
 
 | Scenario                        | Criteria Covered | Spec          | Status      |
 | ------------------------------- | ---------------- | ------------- | ----------- |
-| FAQ page loads expected heading | FAQ-1            | `faq.spec.ts` | Implemented |
+| FAQ page loads expected heading | FAQ-1 and FAQ-2  | `faq.spec.ts` | Implemented |
 
 ## Implementation
 
 - **Spec file:** `packages/e2e/src/faq.spec.ts`
-- **Test:** `FAQ: faq page loads expected heading`
+- **Test:** `FAQ: faq page loads expected heading` (FAQ-1 page title and FAQ-2 semester-conversion question)
 - **Status:** Implemented

--- a/packages/e2e/docs/NewProfessor.md
+++ b/packages/e2e/docs/NewProfessor.md
@@ -17,6 +17,7 @@ The new professor route allows users to submit a professor entry and initial rat
 | NEWPROF-2 | The same route renders a mobile-compatible linear form on small viewports         | Must     |
 | NEWPROF-3 | Required fields block submission when left empty and present validation messaging | Must     |
 | NEWPROF-4 | Successful submission surfaces success feedback to the user                       | Must     |
+| NEWPROF-5 | A 4-digit semester course number (1000–5999) is accepted on submit                | Must     |
 
 ## Test Scenarios
 
@@ -26,9 +27,10 @@ The new professor route allows users to submit a professor entry and initial rat
 | New professor form renders on mobile             | NEWPROF-2        | `new-professor.spec.ts` | Implemented |
 | Validation appears for missing required fields   | NEWPROF-3        | `new-professor.spec.ts` | Implemented |
 | Successful new professor submission flow         | NEWPROF-4        | `new-professor.spec.ts` | Implemented |
+| Successful submission with a 4-digit course num  | NEWPROF-5        | `new-professor.spec.ts` | Implemented |
 
 ## Implementation
 
 - **Spec file:** `packages/e2e/src/new-professor.spec.ts`
-- **Tests:** `NEWPROF: desktop route renders new professor form`, `NEWPROF: mobile route renders linear submit flow`, `NEWPROF: empty required fields are blocked with validation state`, `NEWPROF: successful submission surfaces user feedback` (`{ tag: "@write" }`; skipped in production)
+- **Tests:** `NEWPROF: desktop route renders new professor form`, `NEWPROF: mobile route renders linear submit flow`, `NEWPROF: empty required fields are blocked with validation state`, `NEWPROF: successful submission surfaces user feedback` (`{ tag: "@write" }`; skipped in production), `NEWPROF: successful submission with a 4-digit semester course number` (`{ tag: "@write" }`; skipped in production)
 - **Status:** Implemented

--- a/packages/e2e/src/faq.spec.ts
+++ b/packages/e2e/src/faq.spec.ts
@@ -7,5 +7,10 @@ test("FAQ: faq page loads expected heading", async ({ page }) => {
         await expect(
             page.getByRole("heading", { name: "Frequently Asked Questions" }),
         ).toBeVisible();
+        await expect(
+            page.getByRole("heading", {
+                name: "How do I rate a class after Cal Poly switched to semesters?",
+            }),
+        ).toBeVisible();
     });
 });

--- a/packages/e2e/src/new-professor.spec.ts
+++ b/packages/e2e/src/new-professor.spec.ts
@@ -67,3 +67,30 @@ test("NEWPROF: successful submission surfaces user feedback", { tag: "@write" },
         ).toBeVisible();
     });
 });
+
+test("NEWPROF: successful submission with a 4-digit semester course number", { tag: "@write" }, async ({
+    page,
+}) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/new-professor");
+
+    await test.step("NEWPROF-5: 4-digit course number is accepted after semester conversion", async () => {
+        const uniqueSuffix = Date.now().toString();
+        await expect(page.getByRole("heading", { name: "Professor" })).toBeVisible();
+        await page.locator('input[name="professorFirstName"]:visible').fill(`E2E${uniqueSuffix}`);
+        await page
+            .locator('input[name="professorLastName"]:visible')
+            .fill(`Semester${uniqueSuffix}`);
+        await page.locator('input[name="courseNum"]:visible').fill("2231");
+        await page
+            .locator('textarea[name="ratingText"]:visible')
+            .fill("This is an end-to-end rating body with enough characters.");
+
+        await page.getByRole("button", { name: "Submit" }).click();
+        await expect(
+            page.getByText(
+                /Thank you for adding a professor|automatically added to .*Please reach out/i,
+            ),
+        ).toBeVisible();
+    });
+});

--- a/packages/e2e/src/professor-page.spec.ts
+++ b/packages/e2e/src/professor-page.spec.ts
@@ -30,7 +30,7 @@ test("PROF: professor page renders profile, ratings context, evaluate action, an
         await expect(
             page
                 .locator("h3")
-                .filter({ hasText: /[A-Z]{2,5}\s\d{3}/ })
+                .filter({ hasText: /[A-Z]{2,5}\s\d{3,4}/ })
                 .first(),
         ).toBeVisible();
     });

--- a/packages/frontend/src/components/EvaluateProfessorForm.tsx
+++ b/packages/frontend/src/components/EvaluateProfessorForm.tsx
@@ -11,6 +11,7 @@ import {
     PROFESSOR_TAGS,
     MAX_PROFESSOR_TAGS_PER_RATING,
 } from "@backend/utils/const";
+import { COURSE_NUM_HINT, courseNumParser } from "@backend/utils/courseNum";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { inferProcedureOutput } from "@trpc/server";
@@ -259,18 +260,24 @@ function EvaluateProfessorStep({
                         <TextInput
                             label="Course Num"
                             type="number"
-                            placeholder="class #"
+                            placeholder="101 or 1101"
+                            aria-describedby="unknown-course-num-hint"
                             {...register("unknownCourseNumber", {
                                 required: {
                                     value: !knownCourseValue,
                                     message: "Class Number is required",
                                 },
                             })}
-                            error={errors.unknownCourseDepartment?.message}
+                            error={errors.unknownCourseNumber?.message}
                         />
                     </>
                 )}
             </div>
+            <p id="unknown-course-num-hint" className="text-xs text-gray-600 mt-1 w-full">
+                {knownCourseValue
+                    ? "Fall 2026+ courses use 4-digit numbers. Choose Other if yours is not listed."
+                    : COURSE_NUM_HINT}
+            </p>
             <div className="flex sm:block justify-between">
                 <div className="mt-2 flex flex-col sm:flex-row gap-2 justify-between flex-wrap">
                     {NUMERICAL_RATINGS.map((rating) => (
@@ -423,11 +430,7 @@ const evaluateProfessorFormParser = z.object({
     presentsMaterialClearly: z.string().transform(Number),
     ratingText: z.string().min(20, { error: "Rating text must be at least 20 characters long" }),
     unknownCourseDepartment: z.enum(DEPARTMENT_LIST).optional(),
-    unknownCourseNumber: z.coerce
-        .number()
-        .min(100, { error: "Invalid" })
-        .max(599, { error: "Invalid" })
-        .optional(),
+    unknownCourseNumber: z.coerce.number().pipe(courseNumParser).optional(),
     gradeLevel: z.enum(GRADE_LEVELS),
     grade: z.enum(GRADES),
     courseType: z.enum(COURSE_TYPES),

--- a/packages/frontend/src/components/NewProfessorForm.tsx
+++ b/packages/frontend/src/components/NewProfessorForm.tsx
@@ -9,6 +9,7 @@ import {
     GRADE_LEVELS,
     PROFESSOR_TAGS,
 } from "@backend/utils/const";
+import { COURSE_NUM_HINT, courseNumParser } from "@backend/utils/courseNum";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
@@ -37,10 +38,7 @@ const newProfessorFormParser = z.object({
         .trim()
         .min(20, { error: "Rating text must be at least 20 characters long" }),
     courseDepartment: z.enum(DEPARTMENT_LIST),
-    courseNum: z.preprocess(
-        (val) => parseInt(z.string().parse(val), 10),
-        z.number().min(100, { error: "Invalid" }).max(599, { error: "Invalid" }),
-    ),
+    courseNum: z.preprocess((val) => parseInt(z.string().parse(val), 10), courseNumParser),
     gradeLevel: z.enum(GRADE_LEVELS),
     grade: z.enum(GRADES),
     courseType: z.enum(COURSE_TYPES),
@@ -245,11 +243,15 @@ function NewProfessorStep({
                 <TextInput
                     label="Course Num"
                     type="number"
-                    placeholder="class #"
+                    placeholder="101 or 1101"
+                    aria-describedby="course-num-hint"
                     {...register("courseNum")}
                     error={errors.courseNum?.message}
                 />
             </div>
+            <p id="course-num-hint" className="text-xs text-gray-600 mt-1 w-full">
+                {COURSE_NUM_HINT}
+            </p>
             <div className="flex sm:block justify-between">
                 <div className="mt-2 flex flex-col sm:flex-row gap-3 sm:gap-2 justify-between flex-wrap">
                     {NUMERICAL_RATINGS.map((rating) => (

--- a/packages/frontend/src/pages/FAQ.tsx
+++ b/packages/frontend/src/pages/FAQ.tsx
@@ -138,6 +138,17 @@ export function FAQ() {
                     pull request!
                 </p>
             </div>
+            <div className={cardStyle}>
+                <h2 className={subTitleStyle}>
+                    How do I rate a class after Cal Poly switched to semesters?
+                </h2>
+                <p className={paragraphStyle}>
+                    Starting Fall 2026, Cal Poly course numbers are 4 digits (for example PHIL
+                    2231). Older quarter courses stay 3 digits (PHIL 231) and are listed separately.
+                    If the semester course is not in the dropdown yet, choose Other and enter the
+                    4-digit number.
+                </p>
+            </div>
             <div className={`${cardStyle} rounded-b-md`}>
                 <h2 className={subTitleStyle}>
                     I&apos;m a student/professor, and I&apos;ve seen a comment <i>you</i> wrote on

--- a/packages/frontend/src/utils/courseNum.spec.ts
+++ b/packages/frontend/src/utils/courseNum.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { courseNumParser, courseReviewsKey } from "@backend/utils/courseNum";
+
+describe("courseNumParser", () => {
+    it("accepts historical quarter numbers and semester numbers", () => {
+        expect(courseNumParser.parse(101)).toBe(101);
+        expect(courseNumParser.parse(599)).toBe(599);
+        expect(courseNumParser.parse(1000)).toBe(1000);
+        expect(courseNumParser.parse(2231)).toBe(2231);
+        expect(courseNumParser.parse(5999)).toBe(5999);
+    });
+
+    it("rejects numbers outside quarter and semester ranges", () => {
+        expect(courseNumParser.safeParse(99).success).toBe(false);
+        expect(courseNumParser.safeParse(600).success).toBe(false);
+        expect(courseNumParser.safeParse(999).success).toBe(false);
+        expect(courseNumParser.safeParse(6000).success).toBe(false);
+        expect(courseNumParser.safeParse(101.5).success).toBe(false);
+    });
+});
+
+describe("courseReviewsKey", () => {
+    it("formats department and number with a single space", () => {
+        expect(courseReviewsKey("PHIL", 231)).toBe("PHIL 231");
+        expect(courseReviewsKey("PHIL", 2231)).toBe("PHIL 2231");
+    });
+});


### PR DESCRIPTION
## Summary
- Allow quarter (`100–599`) and semester (`1000–5999`) course numbers so Fall 2026 ratings can be submitted without remapping historical `HIST 213`-style keys.
- Add missing 2026–28 SLO codes to `DEPARTMENT_LIST` (used for both professor and course department dropdowns) and explain the 4-digit / Other flow in the evaluate form and FAQ.

Fixes #224

## Test plan
- [ ] Submit a rating with a 4-digit number (e.g. `2231`) via New Professor and via Evaluate → Other
- [ ] Confirm an existing 3-digit course (e.g. `HIST 213`) still submits and displays as its own section
- [ ] Confirm new department codes appear in both department dropdowns (e.g. `EIM`, `WGQS`, `NUTR`)
- [ ] Skim FAQ “How do I rate a class after Cal Poly switched to semesters?”


Made with [Cursor](https://cursor.com)