### PR TITLE
chore(backend): replace ZodTypeAny and substr with supported APIs

### DIFF
--- a/packages/backend/src/dao/auth-strategy.ts
+++ b/packages/backend/src/dao/auth-strategy.ts
@@ -27,8 +27,8 @@ export class AuthStrategy {
     async verifyHash(hashedPassword: string, password: string): Promise<boolean> {
         const textEncoder = new TextEncoder();
 
-        const salt = hashedPassword.substr(0, AuthStrategy.SALT_SIZE);
-        const storedHash = hashedPassword.substr(AuthStrategy.SALT_SIZE);
+        const salt = hashedPassword.slice(0, AuthStrategy.SALT_SIZE);
+        const storedHash = hashedPassword.slice(AuthStrategy.SALT_SIZE);
 
         const combined = salt + password;
 

--- a/packages/backend/src/dao/kv-dao.ts
+++ b/packages/backend/src/dao/kv-dao.ts
@@ -69,8 +69,8 @@ export class KVDAO {
         return this.polyratingsNamespace.getOptional(professorParser, id);
     }
 
-    getBulkNamespace(bulkKey: BulkKey): { namespace: KvWrapper; parser: z.ZodTypeAny } {
-        const namespaceMap: Record<BulkKey, { namespace: KvWrapper; parser: z.ZodTypeAny }> = {
+    getBulkNamespace(bulkKey: BulkKey): { namespace: KvWrapper; parser: z.ZodType } {
+        const namespaceMap: Record<BulkKey, { namespace: KvWrapper; parser: z.ZodType }> = {
             professors: { namespace: this.polyratingsNamespace, parser: professorParser },
             "professor-queue": {
                 namespace: this.professorApprovalQueueNamespace,

--- a/packages/backend/src/dao/kv-wrapper.ts
+++ b/packages/backend/src/dao/kv-wrapper.ts
@@ -1,10 +1,10 @@
 import { TRPCError } from "@trpc/server";
-import type { output, infer as zodInfer, ZodSafeParseResult, ZodTypeAny } from "zod";
+import type { output, infer as zodInfer, ZodSafeParseResult, ZodType } from "zod";
 
 export class KvWrapper {
     constructor(private kv: KVNamespace) {}
 
-    async get<T extends ZodTypeAny>(parser: T, key: string): Promise<zodInfer<T>> {
+    async get<T extends ZodType>(parser: T, key: string): Promise<zodInfer<T>> {
         const json = await this.kv.get(key, "json");
         if (!json) {
             throw new TRPCError({ code: "NOT_FOUND" });
@@ -12,7 +12,7 @@ export class KvWrapper {
         return parser.parse(json);
     }
 
-    async safeGet<T extends ZodTypeAny>(
+    async safeGet<T extends ZodType>(
         parser: T,
         key: string,
     ): Promise<ZodSafeParseResult<output<T>>> {
@@ -20,10 +20,7 @@ export class KvWrapper {
         return parser.safeParse(json);
     }
 
-    async getOptional<T extends ZodTypeAny>(
-        parser: T,
-        key: string,
-    ): Promise<zodInfer<T> | undefined> {
+    async getOptional<T extends ZodType>(parser: T, key: string): Promise<zodInfer<T> | undefined> {
         try {
             const value = await this.get(parser, key);
             return value;
@@ -39,7 +36,7 @@ export class KvWrapper {
         return this.kv.get(key, "json");
     }
 
-    async getAll<T extends ZodTypeAny>(parser: T): Promise<zodInfer<T>[]> {
+    async getAll<T extends ZodType>(parser: T): Promise<zodInfer<T>[]> {
         const list = await this.kv.list();
         const possiblyNullJson = await Promise.all(
             list.keys.map((key) => this.kv.get(key.name, "json")),
@@ -47,7 +44,7 @@ export class KvWrapper {
         return possiblyNullJson.filter((exists) => exists).map((json) => parser.parse(json));
     }
 
-    put<T extends ZodTypeAny, U extends zodInfer<T>>(
+    put<T extends ZodType, U extends zodInfer<T>>(
         parser: T,
         key: string,
         data: U,


### PR DESCRIPTION
## Summary
- Replace deprecated `ZodTypeAny` with `ZodType` in KV DAO/wrapper generics
- Replace deprecated `substr` with `slice` in auth password hashing

## Test plan
- [ ] `npm run build` (backend)
- [ ] `npm run lint`

Made with [Cursor](https://cursor.com)