### PR TITLE
feat: add sitemap, robots, and PageMeta SEO plumbing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Per-package: `start:local` (frontend/backend), `npm t` (frontend Vitest), `run:l
 
 ## Stack and conventions
 
-- **Frontend:** React 18, Vite, Tailwind (inline classes), tRPC, TanStack Query, React Router. `index.ts` re-exports; no `../` imports. One public component per file. Local error UX at the query/mutation; `meta.suppressGlobalErrorToast` when handled locally.
+- **Frontend:** React 18, Vite, Tailwind (inline classes), tRPC, TanStack Query, React Router. `index.ts` re-exports; no `../` imports. One public component per file. Local error UX at the query/mutation; `meta.suppressGlobalErrorToast` when handled locally. Public routes set unique titles/canonicals with `PageMeta`; keep `docs/seo.md`, `packages/frontend/public/robots.txt`, and `SITEMAP_STATIC_PATHS` in sync when adding indexable pages.
 - **Backend:** Workers, tRPC (`src/index.ts`), KV DAOs, Zod in `src/types/schema.ts` (public vs internal parsers). Public routes: `publicProcedure` and omit `anonymousIdentifier`. Discord notifications production-only; e2e sends `x-polyratings-skip-notifications: 1`.
 - **General:** TypeScript; `@polyratings/eslint-config`; `npm run fix` before commit.
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,8 +8,10 @@ import { professorRouter } from "./routers/professor";
 import { ratingsRouter } from "./routers/rating";
 import { adminRouter } from "./routers/admin";
 import { authRouter } from "./routers/auth";
-import { professorParser, truncatedProfessorParser } from "./types/schema";
+import { professorParser } from "./types/schema";
+import { professorToTruncatedProfessor } from "./types/schemaHelpers";
 import { ALL_PROFESSOR_KEY } from "./utils/const";
+import { buildSitemapXml } from "./utils/sitemap";
 import { mapInBatches } from "./utils/chunkArray";
 import { AnonymousIdDao } from "./dao/anonymous-id-dao";
 import { SKIP_NOTIFICATIONS_HEADER } from "./dao/discord-notification-dao";
@@ -57,6 +59,29 @@ export default {
                 allowedSearchParams: /(.*)/,
             },
         });
+
+        const requestPath = new URL(request.url).pathname;
+        if (
+            request.method === "GET" &&
+            (requestPath === "/sitemap.xml" || requestPath === "/sitemap.xml/")
+        ) {
+            try {
+                const professors = await polyratingsEnv.kvDao.getAllProfessors();
+                return new Response(buildSitemapXml(professors), {
+                    headers: {
+                        "Content-Type": "application/xml; charset=utf-8",
+                        "Cache-Control": "public, max-age=3600",
+                        ...CORS_HEADERS,
+                    },
+                });
+            } catch (error) {
+                sentry.captureException(error);
+                return new Response("Sitemap unavailable", {
+                    status: 503,
+                    headers: CORS_HEADERS,
+                });
+            }
+        }
 
         return fetchRequestHandler({
             endpoint: "",
@@ -115,7 +140,7 @@ async function ensureLocalDb(cloudflareEnv: CloudflareEnv, polyratingsEnv: Env) 
     const githubJson = await githubReq.json();
     // Verify that professors are formed correctly
     const parsedProfessors = professorParser.array().parse(githubJson);
-    const truncatedProfessors = truncatedProfessorParser.array().parse(parsedProfessors);
+    const truncatedProfessors = parsedProfessors.map(professorToTruncatedProfessor);
     await cloudflareEnv.POLYRATINGS_TEACHERS.put(
         ALL_PROFESSOR_KEY,
         JSON.stringify(truncatedProfessors),

--- a/packages/backend/src/types/schema.ts
+++ b/packages/backend/src/types/schema.ts
@@ -57,6 +57,8 @@ export const truncatedProfessorParser = z.object({
     studentDifficulties: z.number().min(0).max(4),
     courses: z.string().array(),
     tags: z.partialRecord(z.enum(PROFESSOR_TAGS), z.number()).optional(),
+    // ISO timestamp of the most recent review; omitted on older index blobs.
+    lastRatingDate: z.string().optional(),
 });
 export type TruncatedProfessor = z.infer<typeof truncatedProfessorParser>;
 

--- a/packages/backend/src/types/schemaHelpers.ts
+++ b/packages/backend/src/types/schemaHelpers.ts
@@ -150,27 +150,32 @@ export function removeRatingsBulk(professor: Professor, ratingIds: string[]): nu
     return removedRatings.length;
 }
 
-export function professorToTruncatedProfessor({
-    id,
-    firstName,
-    lastName,
-    department,
-    courses,
-    numEvals,
-    overallRating,
-    materialClear,
-    studentDifficulties,
-}: Professor): TruncatedProfessor {
+export function getLastRatingDate(professor: Pick<Professor, "reviews">): string | undefined {
+    let latest = Number.NaN;
+    for (const ratings of Object.values(professor.reviews ?? {})) {
+        for (const rating of ratings) {
+            const time = Date.parse(rating.postDate);
+            if (Number.isFinite(time) && (Number.isNaN(latest) || time > latest)) {
+                latest = time;
+            }
+        }
+    }
+    return Number.isNaN(latest) ? undefined : new Date(latest).toISOString();
+}
+
+export function professorToTruncatedProfessor(professor: Professor): TruncatedProfessor {
     return {
-        id,
-        firstName,
-        lastName,
-        department,
-        courses,
-        numEvals,
-        overallRating,
-        materialClear,
-        studentDifficulties,
+        id: professor.id,
+        firstName: professor.firstName,
+        lastName: professor.lastName,
+        department: professor.department,
+        courses: professor.courses,
+        numEvals: professor.numEvals,
+        overallRating: professor.overallRating,
+        materialClear: professor.materialClear,
+        studentDifficulties: professor.studentDifficulties,
+        tags: professor.tags,
+        lastRatingDate: getLastRatingDate(professor),
     };
 }
 

--- a/packages/backend/src/utils/sitemap.ts
+++ b/packages/backend/src/utils/sitemap.ts
@@ -1,0 +1,53 @@
+export const CANONICAL_ORIGIN = "https://polyratings.dev";
+export const SITE_NAME = "Polyratings";
+
+export const SITEMAP_STATIC_PATHS = [
+    "/",
+    "/about",
+    "/faq",
+    "/search/name",
+    "/search/class",
+] as const;
+
+export interface SitemapProfessor {
+    id: string;
+    lastRatingDate?: string;
+}
+
+function xmlEscape(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+}
+
+function toLastmod(isoDate: string | undefined): string | undefined {
+    if (!isoDate) {
+        return undefined;
+    }
+    const timestamp = Date.parse(isoDate);
+    if (Number.isNaN(timestamp)) {
+        return undefined;
+    }
+    return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+function urlEntry(path: string, lastmod?: string): string {
+    const loc = `${CANONICAL_ORIGIN}${path}`;
+    const lastmodTag = lastmod ? `\n    <lastmod>${lastmod}</lastmod>` : "";
+    return `  <url>\n    <loc>${xmlEscape(loc)}</loc>${lastmodTag}\n  </url>`;
+}
+
+export function buildSitemapXml(professors: SitemapProfessor[]): string {
+    const staticEntries = SITEMAP_STATIC_PATHS.map((path) => urlEntry(path));
+    const professorEntries = professors.map((professor) =>
+        urlEntry(`/professor/${professor.id}`, toLastmod(professor.lastRatingDate)),
+    );
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${[...staticEntries, ...professorEntries].join("\n")}
+</urlset>
+`;
+}

--- a/packages/cron/src/steps/generateAllProfessorEntry.ts
+++ b/packages/cron/src/steps/generateAllProfessorEntry.ts
@@ -1,5 +1,6 @@
 import { cloudflareNamespaceInformation } from "@backend/generated/tomlGenerated";
-import { truncatedProfessorParser } from "@backend/types/schema";
+import { Professor, truncatedProfessorParser } from "@backend/types/schema";
+import { professorToTruncatedProfessor } from "@backend/types/schemaHelpers";
 import { ALL_PROFESSOR_KEY } from "@backend/utils/const";
 import { bulkRecord } from "../utils/bulkRecord";
 import { CronEnv } from "../entry";
@@ -14,7 +15,11 @@ export async function generateAllProfessorEntry(env: CronEnv) {
 
     const truncatedProfessorList = truncatedProfessorParser
         .array()
-        .parse(Object.values(allProfessors));
+        .parse(
+            Object.values(allProfessors).map((professor) =>
+                professorToTruncatedProfessor(professor as Professor),
+            ),
+        );
 
     const prodProfessors = new env.KVWrapper(
         cloudflareNamespaceInformation.POLYRATINGS_TEACHERS.prod,

--- a/packages/frontend/public/robots.txt
+++ b/packages/frontend/public/robots.txt
@@ -1,2 +1,7 @@
 User-agent: *
 Allow: /
+
+Disallow: /login
+Disallow: /admin
+
+Sitemap: https://polyratings.dev/sitemap.xml

--- a/packages/frontend/src/components/PageMeta.spec.tsx
+++ b/packages/frontend/src/components/PageMeta.spec.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PageMeta } from "./PageMeta";
+
+afterEach(() => {
+    cleanup();
+    document.getElementById("page-json-ld")?.remove();
+});
+
+describe("PageMeta", () => {
+    it("writes title, description, canonical, and robots into the document head", () => {
+        render(<PageMeta title="About" description="History of Polyratings." path="/about" />);
+
+        expect(document.title).toBe("About · Polyratings");
+        expect(document.querySelector("meta[name=description]")?.getAttribute("content")).toBe(
+            "History of Polyratings.",
+        );
+        expect(document.querySelector("link[rel=canonical]")?.getAttribute("href")).toBe(
+            "https://polyratings.dev/about",
+        );
+        expect(document.querySelector("meta[name=robots]")?.getAttribute("content")).toBe(
+            "index, follow",
+        );
+        expect(document.querySelector("[property='og:title']")?.getAttribute("content")).toBe(
+            "About · Polyratings",
+        );
+    });
+
+    it("marks noindex pages and injects JSON-LD", () => {
+        render(
+            <PageMeta
+                title="Page not found"
+                description="Missing."
+                path="/missing"
+                noindex
+                jsonLd={{ "@type": "Person", name: "Test" }}
+            />,
+        );
+
+        expect(document.querySelector("meta[name=robots]")?.getAttribute("content")).toBe(
+            "noindex, nofollow",
+        );
+        expect(document.getElementById("page-json-ld")?.textContent).toContain("Test");
+    });
+});

--- a/packages/frontend/src/components/PageMeta.tsx
+++ b/packages/frontend/src/components/PageMeta.tsx
@@ -1,0 +1,76 @@
+import { useLayoutEffect } from "react";
+import { canonicalUrl, formatTitle, robotsContent, SITE_NAME } from "@/utils/seo";
+
+interface PageMetaProps {
+    title?: string;
+    description: string;
+    path: string;
+    noindex?: boolean;
+    jsonLd?: unknown;
+}
+
+function upsertMeta(attr: "name" | "property", key: string, content: string) {
+    const selector = `meta[${attr}="${key}"]`;
+    const existing = document.head.querySelector(selector);
+    const element = existing instanceof HTMLMetaElement ? existing : document.createElement("meta");
+    if (!(existing instanceof HTMLMetaElement)) {
+        element.setAttribute(attr, key);
+        document.head.appendChild(element);
+    }
+    element.setAttribute("content", content);
+}
+
+function upsertLink(rel: string, href: string) {
+    const selector = `link[rel="${rel}"]`;
+    const existing = document.head.querySelector(selector);
+    const element = existing instanceof HTMLLinkElement ? existing : document.createElement("link");
+    if (!(existing instanceof HTMLLinkElement)) {
+        element.rel = rel;
+        document.head.appendChild(element);
+    }
+    element.href = href;
+}
+
+function upsertJsonLd(jsonLd: unknown) {
+    const existing = document.getElementById("page-json-ld");
+    if (!jsonLd) {
+        existing?.remove();
+        return;
+    }
+    const script =
+        existing instanceof HTMLScriptElement ? existing : document.createElement("script");
+    script.id = "page-json-ld";
+    script.type = "application/ld+json";
+    script.textContent = JSON.stringify(jsonLd);
+    if (!existing) {
+        document.head.appendChild(script);
+    }
+}
+
+export function PageMeta({ title, description, path, noindex = false, jsonLd }: PageMetaProps) {
+    const documentTitle = formatTitle(title);
+    const canonical = canonicalUrl(path);
+    const jsonLdSerialized = jsonLd === undefined ? undefined : JSON.stringify(jsonLd);
+
+    useLayoutEffect(() => {
+        document.title = documentTitle;
+        upsertMeta("name", "description", description);
+        upsertMeta(
+            "name",
+            "robots",
+            robotsContent({ noindex, hostname: window.location.hostname }),
+        );
+        upsertLink("canonical", canonical);
+        upsertMeta("property", "og:site_name", SITE_NAME);
+        upsertMeta("property", "og:type", "website");
+        upsertMeta("property", "og:title", documentTitle);
+        upsertMeta("property", "og:description", description);
+        upsertMeta("property", "og:url", canonical);
+        upsertMeta("name", "twitter:card", "summary");
+        upsertMeta("name", "twitter:title", documentTitle);
+        upsertMeta("name", "twitter:description", description);
+        upsertJsonLd(jsonLdSerialized ? JSON.parse(jsonLdSerialized) : undefined);
+    }, [canonical, description, documentTitle, jsonLdSerialized, noindex]);
+
+    return null;
+}

--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./EvaluateProfessorForm";
 export * from "./Navbar";
+export * from "./PageMeta";
 export * from "./NewProfessorForm";
 export * from "./SearchBar";
 export * from "./ProfessorCard";

--- a/packages/frontend/src/utils/index.ts
+++ b/packages/frontend/src/utils/index.ts
@@ -3,4 +3,5 @@ export * from "./intersectingDbEntities";
 export * from "./BasicBehaviorSubject";
 export * from "./getApiErrorMessage";
 export * from "./applyProfessorFilters";
+export * from "./seo";
 export { chunkArray, mapInBatches } from "@backend/utils/chunkArray";

--- a/packages/frontend/src/utils/seo.spec.ts
+++ b/packages/frontend/src/utils/seo.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { buildSitemapXml } from "@backend/utils/sitemap";
+import {
+    canonicalUrl,
+    formatTitle,
+    professorPageDescription,
+    professorPageTitle,
+    robotsContent,
+    shouldNoindexHost,
+} from "./seo";
+
+describe("seo helpers", () => {
+    it("formats titles with the site name", () => {
+        expect(formatTitle()).toBe("Polyratings");
+        expect(formatTitle("About")).toBe("About · Polyratings");
+    });
+
+    it("builds apex canonical URLs without trailing slashes except home", () => {
+        expect(canonicalUrl("/")).toBe("https://polyratings.dev/");
+        expect(canonicalUrl("/about/")).toBe("https://polyratings.dev/about");
+        expect(canonicalUrl("faq")).toBe("https://polyratings.dev/faq");
+    });
+
+    it("noindexes non-production hosts", () => {
+        expect(shouldNoindexHost("polyratings.dev")).toBe(false);
+        expect(shouldNoindexHost("localhost")).toBe(false);
+        expect(shouldNoindexHost("polyratings.pages.dev")).toBe(true);
+        expect(shouldNoindexHost("www.polyratings.dev")).toBe(true);
+        expect(robotsContent({ hostname: "polyratings.pages.dev" })).toBe("noindex, nofollow");
+        expect(robotsContent({ noindex: true, hostname: "polyratings.dev" })).toBe(
+            "noindex, nofollow",
+        );
+        expect(robotsContent({ hostname: "polyratings.dev" })).toBe("index, follow");
+    });
+
+    it("describes professor pages from live stats", () => {
+        const professor = {
+            firstName: "Parisa",
+            lastName: "Mahjoor",
+            department: "CHEM",
+            numEvals: 17,
+            overallRating: 0.64,
+        };
+        expect(professorPageTitle(professor)).toBe("Mahjoor, Parisa");
+        expect(professorPageDescription(professor)).toBe(
+            "Student ratings for Parisa Mahjoor (CHEM) at Cal Poly. 17 reviews, overall 0.64 out of 4.",
+        );
+    });
+});
+
+describe("sitemap xml", () => {
+    it("includes static routes and professor lastmod when known", () => {
+        const xml = buildSitemapXml([
+            {
+                id: "0038ea39-3910-4f80-9353-41dce33c754d",
+                lastRatingDate: "2026-01-15T00:00:00.000Z",
+            },
+            { id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" },
+        ]);
+        expect(xml).toContain("<loc>https://polyratings.dev/</loc>");
+        expect(xml).toContain("<loc>https://polyratings.dev/search/name</loc>");
+        expect(xml).toContain(
+            "<loc>https://polyratings.dev/professor/0038ea39-3910-4f80-9353-41dce33c754d</loc>",
+        );
+        expect(xml).toContain("<lastmod>2026-01-15</lastmod>");
+        expect(xml).not.toContain("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n    <lastmod>");
+    });
+});

--- a/packages/frontend/src/utils/seo.ts
+++ b/packages/frontend/src/utils/seo.ts
@@ -1,0 +1,128 @@
+import { CANONICAL_ORIGIN, SITE_NAME } from "@backend/utils/sitemap";
+
+export { CANONICAL_ORIGIN, SITE_NAME };
+
+export const DEFAULT_DESCRIPTION =
+    "Student ratings of Cal Poly professors. Read reviews, compare courses, and find the right instructor.";
+
+export const PRODUCTION_HOSTNAME = "polyratings.dev";
+
+export function formatTitle(pageTitle?: string): string {
+    return pageTitle ? `${pageTitle} · ${SITE_NAME}` : SITE_NAME;
+}
+
+export function canonicalUrl(path: string): string {
+    const normalized = path.startsWith("/") ? path : `/${path}`;
+    if (normalized === "/") {
+        return `${CANONICAL_ORIGIN}/`;
+    }
+    return `${CANONICAL_ORIGIN}${normalized.replace(/\/+$/, "")}`;
+}
+
+export function shouldNoindexHost(hostname: string): boolean {
+    if (hostname === "localhost" || hostname === "127.0.0.1") {
+        return false;
+    }
+    return hostname !== PRODUCTION_HOSTNAME;
+}
+
+export function robotsContent(options: { noindex?: boolean; hostname?: string }): string {
+    if (options.noindex || (options.hostname && shouldNoindexHost(options.hostname))) {
+        return "noindex, nofollow";
+    }
+    return "index, follow";
+}
+
+export function professorPageTitle(professor: { firstName: string; lastName: string }): string {
+    return `${professor.lastName}, ${professor.firstName}`;
+}
+
+export function professorPageDescription(professor: {
+    firstName: string;
+    lastName: string;
+    department: string;
+    numEvals: number;
+    overallRating: number;
+}): string {
+    const name = `${professor.firstName} ${professor.lastName}`;
+    if (professor.numEvals <= 0) {
+        return `Student ratings for ${name} (${professor.department}) at Cal Poly on Polyratings.`;
+    }
+    const reviews = professor.numEvals === 1 ? "review" : "reviews";
+    return (
+        `Student ratings for ${name} (${professor.department}) at Cal Poly. ` +
+        `${professor.numEvals} ${reviews}, overall ${professor.overallRating.toFixed(2)} out of 4.`
+    );
+}
+
+export function professorJsonLd(
+    professor: {
+        id: string;
+        firstName: string;
+        lastName: string;
+        department: string;
+        numEvals: number;
+        overallRating: number;
+    },
+    path: string,
+) {
+    const name = `${professor.firstName} ${professor.lastName}`;
+    const url = canonicalUrl(path);
+    const person: Record<string, unknown> = {
+        "@type": "Person",
+        name,
+        url,
+        jobTitle: "Professor",
+        affiliation: {
+            "@type": "EducationalOrganization",
+            name: "California Polytechnic State University, San Luis Obispo",
+        },
+        worksFor: {
+            "@type": "EducationalOrganization",
+            name: "California Polytechnic State University, San Luis Obispo",
+        },
+        description: professorPageDescription(professor),
+    };
+    if (professor.department) {
+        person.department = { "@type": "Organization", name: professor.department };
+    }
+    if (professor.numEvals > 0) {
+        person.aggregateRating = {
+            "@type": "AggregateRating",
+            ratingValue: professor.overallRating,
+            bestRating: 4,
+            worstRating: 0,
+            ratingCount: professor.numEvals,
+        };
+    }
+
+    return {
+        "@context": "https://schema.org",
+        "@graph": [
+            person,
+            {
+                "@type": "BreadcrumbList",
+                itemListElement: [
+                    {
+                        "@type": "ListItem",
+                        position: 1,
+                        name: SITE_NAME,
+                        item: `${CANONICAL_ORIGIN}/`,
+                    },
+                    {
+                        "@type": "ListItem",
+                        position: 2,
+                        name: "Professors",
+                        item: `${CANONICAL_ORIGIN}/search/name`,
+                    },
+                    {
+                        "@type": "ListItem",
+                        position: 3,
+                        name,
+                        item: url,
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/packages/frontend/vite-plugin-sitemap.ts
+++ b/packages/frontend/vite-plugin-sitemap.ts
@@ -1,0 +1,75 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Plugin } from "vite";
+// Vite loads this file before tsconfig path aliases exist.
+/* eslint-disable no-restricted-imports, import/no-relative-packages */
+import { BETA_ENV, DEV_ENV, LOCAL_ENV, PROD_ENV } from "../backend/src/generated/tomlGenerated";
+import { buildSitemapXml, type SitemapProfessor } from "../backend/src/utils/sitemap";
+/* eslint-enable no-restricted-imports, import/no-relative-packages */
+
+function apiUrlForMode(mode: string): string {
+    const fromEnv = process.env.VITE_API_URL?.replace(/\/$/, "");
+    if (fromEnv) {
+        return fromEnv;
+    }
+    if (mode === "local-dev") {
+        return LOCAL_ENV.url;
+    }
+    if (mode === "master" || mode === "production") {
+        return PROD_ENV.url;
+    }
+    if (mode === "beta") {
+        return BETA_ENV.url;
+    }
+    return DEV_ENV.url;
+}
+
+function unwrapProfessorList(body: unknown): SitemapProfessor[] {
+    if (!body || typeof body !== "object") {
+        return [];
+    }
+    const data = (body as { result?: { data?: unknown } }).result?.data;
+    if (Array.isArray(data)) {
+        return data as SitemapProfessor[];
+    }
+    if (data && typeof data === "object" && Array.isArray((data as { json?: unknown }).json)) {
+        return (data as { json: SitemapProfessor[] }).json;
+    }
+    return [];
+}
+
+export function sitemapPlugin(): Plugin {
+    let mode = "production";
+    let outFile = "";
+
+    return {
+        name: "polyratings-sitemap",
+        apply: "build",
+        configResolved(config) {
+            mode = config.mode;
+            outFile = resolve(config.root, config.build.outDir, "sitemap.xml");
+        },
+        async closeBundle() {
+            let professors: SitemapProfessor[] = [];
+            try {
+                const response = await fetch(`${apiUrlForMode(mode)}/professors.all`);
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}`);
+                }
+                professors = unwrapProfessorList(await response.json());
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                configWarn(
+                    `sitemap: could not load professors (${message}); writing static URLs only`,
+                );
+            }
+            writeFileSync(outFile, buildSitemapXml(professors));
+        },
+    };
+}
+
+function configWarn(message: string) {
+    // Build-time diagnostic for a missing professor index; not shipped to the browser.
+    // eslint-disable-next-line no-console
+    console.warn(message);
+}

--- a/packages/frontend/vite.config.mts
+++ b/packages/frontend/vite.config.mts
@@ -1,11 +1,12 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { sitemapPlugin } from "./vite-plugin-sitemap.ts";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "/",
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), sitemapPlugin()],
     resolve: {
         tsconfigPaths: true,
     },


### PR DESCRIPTION
## Summary
- Serve `/sitemap.xml` from the backend worker with static routes and professor URLs
- Add `lastRatingDate` to truncated professor index blobs (cron + local seed)
- Add frontend `PageMeta`, `seo` utils, build-time sitemap plugin, and `robots.txt`

## Test plan
- [ ] `npm run build`
- [ ] `npm t` in frontend (seo/PageMeta specs)
- [ ] Verify `/sitemap.xml` locally and confirm canonical/robots tags on public pages

Made with [Cursor](https://cursor.com)