### PR TITLE
feat(search): improve professor ranking with nicknames and recency

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,7 +8,8 @@ import { professorRouter } from "./routers/professor";
 import { ratingsRouter } from "./routers/rating";
 import { adminRouter } from "./routers/admin";
 import { authRouter } from "./routers/auth";
-import { professorParser, truncatedProfessorParser } from "./types/schema";
+import { professorParser } from "./types/schema";
+import { professorToTruncatedProfessor } from "./types/schemaHelpers";
 import { ALL_PROFESSOR_KEY } from "./utils/const";
 import { mapInBatches } from "./utils/chunkArray";
 import { AnonymousIdDao } from "./dao/anonymous-id-dao";
@@ -115,7 +116,7 @@ async function ensureLocalDb(cloudflareEnv: CloudflareEnv, polyratingsEnv: Env) 
     const githubJson = await githubReq.json();
     // Verify that professors are formed correctly
     const parsedProfessors = professorParser.array().parse(githubJson);
-    const truncatedProfessors = truncatedProfessorParser.array().parse(parsedProfessors);
+    const truncatedProfessors = parsedProfessors.map(professorToTruncatedProfessor);
     await cloudflareEnv.POLYRATINGS_TEACHERS.put(
         ALL_PROFESSOR_KEY,
         JSON.stringify(truncatedProfessors),

--- a/packages/backend/src/types/schema.ts
+++ b/packages/backend/src/types/schema.ts
@@ -57,6 +57,8 @@ export const truncatedProfessorParser = z.object({
     studentDifficulties: z.number().min(0).max(4),
     courses: z.string().array(),
     tags: z.partialRecord(z.enum(PROFESSOR_TAGS), z.number()).optional(),
+    // ISO timestamp of the most recent review; omitted on older index blobs.
+    lastRatingDate: z.string().optional(),
 });
 export type TruncatedProfessor = z.infer<typeof truncatedProfessorParser>;
 

--- a/packages/backend/src/types/schemaHelpers.ts
+++ b/packages/backend/src/types/schemaHelpers.ts
@@ -150,27 +150,32 @@ export function removeRatingsBulk(professor: Professor, ratingIds: string[]): nu
     return removedRatings.length;
 }
 
-export function professorToTruncatedProfessor({
-    id,
-    firstName,
-    lastName,
-    department,
-    courses,
-    numEvals,
-    overallRating,
-    materialClear,
-    studentDifficulties,
-}: Professor): TruncatedProfessor {
+export function getLastRatingDate(professor: Pick<Professor, "reviews">): string | undefined {
+    let latest = Number.NaN;
+    for (const ratings of Object.values(professor.reviews ?? {})) {
+        for (const rating of ratings) {
+            const time = Date.parse(rating.postDate);
+            if (Number.isFinite(time) && (Number.isNaN(latest) || time > latest)) {
+                latest = time;
+            }
+        }
+    }
+    return Number.isNaN(latest) ? undefined : new Date(latest).toISOString();
+}
+
+export function professorToTruncatedProfessor(professor: Professor): TruncatedProfessor {
     return {
-        id,
-        firstName,
-        lastName,
-        department,
-        courses,
-        numEvals,
-        overallRating,
-        materialClear,
-        studentDifficulties,
+        id: professor.id,
+        firstName: professor.firstName,
+        lastName: professor.lastName,
+        department: professor.department,
+        courses: professor.courses,
+        numEvals: professor.numEvals,
+        overallRating: professor.overallRating,
+        materialClear: professor.materialClear,
+        studentDifficulties: professor.studentDifficulties,
+        tags: professor.tags,
+        lastRatingDate: getLastRatingDate(professor),
     };
 }
 

--- a/packages/cron/src/steps/generateAllProfessorEntry.ts
+++ b/packages/cron/src/steps/generateAllProfessorEntry.ts
@@ -1,5 +1,6 @@
 import { cloudflareNamespaceInformation } from "@backend/generated/tomlGenerated";
-import { truncatedProfessorParser } from "@backend/types/schema";
+import { Professor, truncatedProfessorParser } from "@backend/types/schema";
+import { professorToTruncatedProfessor } from "@backend/types/schemaHelpers";
 import { ALL_PROFESSOR_KEY } from "@backend/utils/const";
 import { bulkRecord } from "../utils/bulkRecord";
 import { CronEnv } from "../entry";
@@ -14,7 +15,11 @@ export async function generateAllProfessorEntry(env: CronEnv) {
 
     const truncatedProfessorList = truncatedProfessorParser
         .array()
-        .parse(Object.values(allProfessors));
+        .parse(
+            Object.values(allProfessors).map((professor) =>
+                professorToTruncatedProfessor(professor as Professor),
+            ),
+        );
 
     const prodProfessors = new env.KVWrapper(
         cloudflareNamespaceInformation.POLYRATINGS_TEACHERS.prod,

--- a/packages/frontend/src/utils/ProfessorSearch.spec.ts
+++ b/packages/frontend/src/utils/ProfessorSearch.spec.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "vitest";
+import { TruncatedProfessor } from "@backend/types/schema";
+import { professorSearch } from "./ProfessorSearch";
+
+function makeProfessor(
+    overrides: Partial<TruncatedProfessor> &
+        Pick<TruncatedProfessor, "id" | "firstName" | "lastName">,
+): TruncatedProfessor {
+    return {
+        department: "CSC",
+        numEvals: 20,
+        overallRating: 3.5,
+        materialClear: 3.5,
+        studentDifficulties: 3.5,
+        courses: ["CSC 101"],
+        ...overrides,
+    };
+}
+
+const now = Date.parse("2026-08-23T00:00:00.000Z");
+
+const chrisLawson = makeProfessor({
+    id: "11111111-1111-4111-8111-111111111111",
+    firstName: "Chris",
+    lastName: "Lawson",
+    numEvals: 40,
+    overallRating: 3.6,
+    lastRatingDate: "2026-01-15T00:00:00.000Z",
+});
+const christopherLane = makeProfessor({
+    id: "22222222-2222-4222-8222-222222222222",
+    firstName: "Christopher",
+    lastName: "Lane",
+    numEvals: 80,
+    overallRating: 3.9,
+    lastRatingDate: "2026-06-01T00:00:00.000Z",
+});
+const michaelChen = makeProfessor({
+    id: "33333333-3333-4333-8333-333333333333",
+    firstName: "Michael",
+    lastName: "Chen",
+    numEvals: 12,
+    overallRating: 3.2,
+    lastRatingDate: "2025-09-01T00:00:00.000Z",
+});
+const michaelChristensen = makeProfessor({
+    id: "44444444-4444-4444-8444-444444444444",
+    firstName: "Michael",
+    lastName: "Christensen",
+    numEvals: 90,
+    overallRating: 3.9,
+    lastRatingDate: "2026-04-01T00:00:00.000Z",
+});
+const staleHighRated = makeProfessor({
+    id: "55555555-5555-4555-8555-555555555555",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    numEvals: 8,
+    overallRating: 4,
+    lastRatingDate: "2016-01-01T00:00:00.000Z",
+});
+const noEvals = makeProfessor({
+    id: "66666666-6666-4666-8666-666666666666",
+    firstName: "Grace",
+    lastName: "Hopper",
+    numEvals: 0,
+    overallRating: 0,
+});
+const recentEstablished = makeProfessor({
+    id: "77777777-7777-4777-8777-777777777777",
+    firstName: "Alan",
+    lastName: "Turing",
+    numEvals: 60,
+    overallRating: 3.8,
+    lastRatingDate: "2026-05-01T00:00:00.000Z",
+    courses: ["CSC 445"],
+});
+const jamesSmith = makeProfessor({
+    id: "88888888-8888-4888-8888-888888888888",
+    firstName: "James",
+    lastName: "Smith",
+    numEvals: 25,
+    overallRating: 3.4,
+    lastRatingDate: "2026-03-01T00:00:00.000Z",
+});
+const williamJones = makeProfessor({
+    id: "99999999-9999-4999-8999-999999999999",
+    firstName: "William",
+    lastName: "Jones",
+    numEvals: 18,
+    overallRating: 3.1,
+    lastRatingDate: "2026-02-01T00:00:00.000Z",
+});
+
+const professors = [
+    noEvals,
+    staleHighRated,
+    christopherLane,
+    chrisLawson,
+    michaelChristensen,
+    michaelChen,
+    recentEstablished,
+    jamesSmith,
+    williamJones,
+];
+
+function search(
+    query: string,
+    type: "name" | "class" = "name",
+    options: { includeStale?: boolean } = {},
+) {
+    return professorSearch(professors, type, query, { now, ...options }).map(
+        (professor) => `${professor.lastName}, ${professor.firstName}`,
+    );
+}
+
+describe("professorSearch name matching", () => {
+    test("ranks first-last queries the same as last-first queries", () => {
+        expect(search("chris lawson")[0]).toBe("Lawson, Chris");
+        expect(search("lawson chris")[0]).toBe("Lawson, Chris");
+        expect(search("Lawson, Chris")[0]).toBe("Lawson, Chris");
+    });
+
+    test("does not let a last-name prefix beat an exact last name while typing", () => {
+        expect(search("michael ch")[0]).toBe("Chen, Michael");
+        expect(search("michael chen")[0]).toBe("Chen, Michael");
+        expect(search("chris l")[0]).toBe("Lawson, Chris");
+    });
+
+    test("does not keep partial-token matches after a second name token", () => {
+        expect(search("chris z")).toEqual([]);
+        expect(search("michael chen")).not.toContain("Christensen, Michael");
+    });
+
+    test("single-token last names still match", () => {
+        expect(search("lawson")[0]).toBe("Lawson, Chris");
+    });
+
+    test("matches common nicknames in either direction", () => {
+        expect(search("jim smith")[0]).toBe("Smith, James");
+        expect(search("james smith")[0]).toBe("Smith, James");
+        expect(search("bill jones")[0]).toBe("Jones, William");
+        expect(search("william jones")[0]).toBe("Jones, William");
+        expect(search("christopher lawson")).toContain("Lawson, Chris");
+        expect(search("mike chen")[0]).toBe("Chen, Michael");
+    });
+
+    test("exact given names still rank above nickname equivalents", () => {
+        expect(search("chris")[0]).toBe("Lawson, Chris");
+        expect(search("christopher")[0]).toBe("Lane, Christopher");
+    });
+});
+
+describe("professorSearch quality ranking", () => {
+    test("empty name search hides professors without a rating in 3 years", () => {
+        const names = search("");
+        expect(names).not.toContain("Lovelace, Ada");
+        expect(names.at(-1)).toBe("Hopper, Grace");
+        expect(names[0]).toBe("Christensen, Michael");
+    });
+
+    test("exact last-name search can still find a stale professor", () => {
+        expect(search("lovelace")).toContain("Lovelace, Ada");
+        expect(search("ada lovelace")[0]).toBe("Lovelace, Ada");
+        expect(search("ada")).not.toContain("Lovelace, Ada");
+    });
+
+    test("includeStale keeps inactive professors in admin-style search", () => {
+        expect(search("", "name", { includeStale: true })).toContain("Lovelace, Ada");
+    });
+
+    test("class search keeps course matches and ranks them by quality", () => {
+        expect(search("CSC 445", "class")).toEqual(["Turing, Alan"]);
+        const unfiltered = search("", "class");
+        expect(unfiltered[0]).toBe("Christensen, Michael");
+        expect(unfiltered).not.toContain("Lovelace, Ada");
+        expect(unfiltered.at(-1)).toBe("Hopper, Grace");
+    });
+});

--- a/packages/frontend/src/utils/ProfessorSearch.ts
+++ b/packages/frontend/src/utils/ProfessorSearch.ts
@@ -1,33 +1,259 @@
-import { AppRouter } from "@backend/index";
-import { inferProcedureOutput } from "@trpc/server";
-import { intersectingDbEntities } from "./intersectingDbEntities";
+import { TruncatedProfessor } from "@backend/types/schema";
+import { namesAreNicknames } from "./nameNicknames";
 
 export type ProfessorSearchType = "name" | "class";
 
+export interface ProfessorSearchOptions {
+    now?: number;
+    includeStale?: boolean;
+}
+
+const RATING_PRIOR = 10;
+const GLOBAL_MEAN = 2.75;
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+/** Hide from casual search if the latest rating is older than this. */
+export const STALE_RATING_YEARS = 3;
+/** Exact last name (100 + 5) or first+last can still surface a stale professor. */
+const STRONG_NAME_SCORE = 101;
+
+interface NameIndex {
+    firstParts: string[];
+    lastParts: string[];
+    firstCollapsed: string;
+    lastCollapsed: string;
+}
+
 export function professorSearch(
-    allProfessors: inferProcedureOutput<AppRouter["professors"]["all"]>,
+    allProfessors: TruncatedProfessor[],
     type: ProfessorSearchType,
     value: string,
-): inferProcedureOutput<AppRouter["professors"]["all"]> {
+    options: ProfessorSearchOptions = {},
+): TruncatedProfessor[] {
+    const now = options.now ?? Date.now();
+    const includeStale = options.includeStale ?? false;
+
     switch (type) {
         case "name": {
-            const tokens = value.toLowerCase().split(" ");
-            const tokenMatches = tokens.map((token) =>
-                allProfessors.filter((professor) =>
-                    `${professor.lastName}, ${professor.firstName}`.toLowerCase().includes(token),
-                ),
-            );
-            const { intersect, nonIntersect } = intersectingDbEntities(tokenMatches);
-            return [...intersect, ...nonIntersect];
+            const tokens = tokenize(value);
+            if (tokens.length === 0) {
+                return rankByQuality(allProfessors, now, includeStale);
+            }
+
+            return allProfessors
+                .map((professor) => ({
+                    professor,
+                    nameScore: nameMatchScore(tokens, indexName(professor)),
+                }))
+                .filter(
+                    (entry) =>
+                        entry.nameScore > 0 &&
+                        (includeStale ||
+                            !isStaleProfessor(entry.professor, now) ||
+                            entry.nameScore >= STRONG_NAME_SCORE),
+                )
+                .sort((a, b) => compareByRelevance(a, b, now))
+                .map((entry) => entry.professor);
         }
         case "class": {
-            const courseName = value.toUpperCase();
-            // use includes to possibly be more lenient
-            return allProfessors.filter((professor) =>
-                professor.courses.find((course) => course.includes(courseName)),
-            );
+            const courseName = value.trim().toUpperCase();
+            const matches = courseName
+                ? allProfessors.filter((professor) =>
+                      professor.courses.some((course) => course.includes(courseName)),
+                  )
+                : allProfessors;
+            return rankByQuality(matches, now, includeStale);
         }
         default:
             throw new Error(`Invalid Search Type: ${type}`);
     }
+}
+
+function rankByQuality(
+    professors: TruncatedProfessor[],
+    now: number,
+    includeStale: boolean,
+): TruncatedProfessor[] {
+    const visible = includeStale
+        ? professors
+        : professors.filter((professor) => !isStaleProfessor(professor, now));
+    return [...visible].sort((a, b) =>
+        compareByRelevance({ professor: a, nameScore: 0 }, { professor: b, nameScore: 0 }, now),
+    );
+}
+
+export function isStaleProfessor(professor: TruncatedProfessor, now = Date.now()): boolean {
+    if (!professor.lastRatingDate) {
+        // Older index blobs omit this field; don't hide the entire catalog.
+        return false;
+    }
+    const time = Date.parse(professor.lastRatingDate);
+    if (!Number.isFinite(time)) {
+        return false;
+    }
+    return now - time > STALE_RATING_YEARS * MS_PER_YEAR;
+}
+
+function compareByRelevance(
+    a: { professor: TruncatedProfessor; nameScore: number },
+    b: { professor: TruncatedProfessor; nameScore: number },
+    now: number,
+): number {
+    if (a.nameScore !== b.nameScore) {
+        return b.nameScore - a.nameScore;
+    }
+    const qualityDelta =
+        professorQualityScore(b.professor, now) - professorQualityScore(a.professor, now);
+    if (qualityDelta !== 0) {
+        return qualityDelta;
+    }
+    return `${a.professor.lastName}, ${a.professor.firstName}`.localeCompare(
+        `${b.professor.lastName}, ${b.professor.firstName}`,
+    );
+}
+
+export function professorQualityScore(professor: TruncatedProfessor, now = Date.now()): number {
+    if (professor.numEvals <= 0) {
+        return 0;
+    }
+
+    const popularity = Math.min(1, Math.log(1 + professor.numEvals) / Math.log(1 + 100));
+    const bayesian =
+        (RATING_PRIOR * GLOBAL_MEAN + professor.numEvals * professor.overallRating) /
+        (RATING_PRIOR + professor.numEvals);
+
+    return (
+        0.5 * popularity + 0.3 * (bayesian / 4) + 0.2 * recencyScore(professor.lastRatingDate, now)
+    );
+}
+
+function recencyScore(lastRatingDate: string | undefined, now: number): number {
+    if (!lastRatingDate) {
+        // Missing dates (pre-backfill) are treated as neutral so we don't bury everyone.
+        return 0.7;
+    }
+    const time = Date.parse(lastRatingDate);
+    if (!Number.isFinite(time)) {
+        return 0.7;
+    }
+    const ageYears = Math.max(0, (now - time) / MS_PER_YEAR);
+    return Math.exp(-ageYears / 4);
+}
+
+function tokenize(value: string): string[] {
+    return normalizeName(value).split(" ").filter(Boolean);
+}
+
+function normalizeName(value: string): string {
+    return value
+        .toLowerCase()
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/[^a-z0-9\s]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+function indexName(professor: TruncatedProfessor): NameIndex {
+    const firstParts = tokenize(professor.firstName);
+    const lastParts = tokenize(professor.lastName);
+    return {
+        firstParts,
+        lastParts,
+        firstCollapsed: firstParts.join(""),
+        lastCollapsed: lastParts.join(""),
+    };
+}
+
+function nameMatchScore(tokens: string[], name: NameIndex): number {
+    if (tokens.length === 1) {
+        const first = scoreAgainst(tokens[0], name.firstParts, name.firstCollapsed);
+        const last = scoreAgainst(tokens[0], name.lastParts, name.lastCollapsed);
+        // Slight last-name preference for directory-style single-token queries.
+        return Math.max(first, last > 0 ? last + 5 : 0);
+    }
+
+    let best = 0;
+    for (let i = 1; i < tokens.length; i += 1) {
+        const left = tokens.slice(0, i);
+        const right = tokens.slice(i);
+        best = Math.max(
+            best,
+            combineScores(
+                scorePhrase(left, name.firstParts, name.firstCollapsed),
+                scorePhrase(right, name.lastParts, name.lastCollapsed),
+            ),
+            combineScores(
+                scorePhrase(left, name.lastParts, name.lastCollapsed),
+                scorePhrase(right, name.firstParts, name.firstCollapsed),
+            ),
+        );
+    }
+    return best;
+}
+
+function combineScores(left: number, right: number): number {
+    if (left <= 0 || right <= 0) {
+        return 0;
+    }
+    return left + right;
+}
+
+function scorePhrase(tokens: string[], parts: string[], collapsed: string): number {
+    if (tokens.length === 1) {
+        return scoreAgainst(tokens[0], parts, collapsed);
+    }
+
+    const collapsedScore = scoreAgainst(tokens.join(""), parts, collapsed);
+    const sequential = tokens.reduce(
+        (state, token) => {
+            if (state.failed) {
+                return state;
+            }
+            const remaining = parts.slice(state.partIndex);
+            const matchIndex = remaining.findIndex((part) => partMatch(token, part) > 0);
+            if (matchIndex === -1) {
+                return { total: 0, partIndex: parts.length, failed: true };
+            }
+            return {
+                total: state.total + partMatch(token, remaining[matchIndex]),
+                partIndex: state.partIndex + matchIndex + 1,
+                failed: false,
+            };
+        },
+        { total: 0, partIndex: 0, failed: false },
+    );
+    const sequentialScore = sequential.failed ? 0 : sequential.total / tokens.length;
+    return Math.max(collapsedScore, sequentialScore);
+}
+
+function scoreAgainst(token: string, parts: string[], collapsed: string): number {
+    let best = parts.reduce((highest, part) => Math.max(highest, partMatch(token, part)), 0);
+    if (collapsed === token) {
+        best = Math.max(best, 95);
+    } else if (collapsed.startsWith(token)) {
+        best = Math.max(best, 60 + 20 * (token.length / Math.max(collapsed.length, 1)));
+    } else if (token.length >= 3 && collapsed.includes(token)) {
+        best = Math.max(best, 15);
+    }
+    return best;
+}
+
+function partMatch(token: string, part: string): number {
+    if (!token || !part) {
+        return 0;
+    }
+    if (part === token) {
+        return 100;
+    }
+    if (namesAreNicknames(token, part)) {
+        // Below exact, above ordinary prefixes, so "chris" still prefers Chris to Christopher.
+        return 88;
+    }
+    if (part.startsWith(token)) {
+        return 70 + 30 * (token.length / part.length);
+    }
+    if (token.length >= 3 && part.includes(token)) {
+        return 20 * (token.length / part.length);
+    }
+    return 0;
 }

--- a/packages/frontend/src/utils/nameNicknames.spec.ts
+++ b/packages/frontend/src/utils/nameNicknames.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { namesAreNicknames } from "./nameNicknames";
+
+describe("namesAreNicknames", () => {
+    test("matches nicknames in both directions", () => {
+        expect(namesAreNicknames("jim", "james")).toBe(true);
+        expect(namesAreNicknames("james", "jim")).toBe(true);
+        expect(namesAreNicknames("chris", "christopher")).toBe(true);
+        expect(namesAreNicknames("christopher", "chris")).toBe(true);
+        expect(namesAreNicknames("mike", "michael")).toBe(true);
+        expect(namesAreNicknames("bill", "william")).toBe(true);
+    });
+
+    test("does not merge distinct names that share a nickname", () => {
+        expect(namesAreNicknames("christopher", "christine")).toBe(false);
+        expect(namesAreNicknames("sam", "samantha")).toBe(true);
+        expect(namesAreNicknames("samuel", "samantha")).toBe(false);
+    });
+
+    test("does not treat unrelated or identical names as nicknames", () => {
+        expect(namesAreNicknames("chris", "chris")).toBe(false);
+        expect(namesAreNicknames("ada", "grace")).toBe(false);
+        expect(namesAreNicknames("lawson", "chris")).toBe(false);
+    });
+});

--- a/packages/frontend/src/utils/nameNicknames.ts
+++ b/packages/frontend/src/utils/nameNicknames.ts
@@ -1,0 +1,135 @@
+/**
+ * Bidirectional given-name nickname groups.
+ * Shared nicknames (e.g. "chris") do not make Christopher ≡ Christine.
+ */
+const NICKNAME_GROUPS: readonly (readonly string[])[] = [
+    ["james", "jim", "jimmy", "jamie"],
+    ["john", "jack", "johnny", "jon"],
+    ["jonathan", "jon", "jonny"],
+    ["robert", "rob", "bob", "bobby", "robbie"],
+    ["william", "will", "bill", "billy", "liam", "willie"],
+    ["richard", "rick", "dick", "rich", "ricky"],
+    ["michael", "mike", "mikey", "mick"],
+    ["christopher", "chris", "kit"],
+    ["christine", "chris", "chrissy", "tina"],
+    ["christina", "chris", "chrissy", "tina"],
+    ["joseph", "joe", "joey"],
+    ["josephine", "jo", "josie"],
+    ["thomas", "tom", "tommy"],
+    ["charles", "chuck", "charlie", "chas"],
+    ["daniel", "dan", "danny"],
+    ["matthew", "matt", "matty"],
+    ["anthony", "tony"],
+    ["andrew", "andy", "drew"],
+    ["david", "dave", "davy"],
+    ["edward", "ed", "ted", "teddy", "eddie"],
+    ["steven", "stephen", "steve", "stevie"],
+    ["benjamin", "ben", "benny"],
+    ["samuel", "sam", "sammy"],
+    ["samantha", "sam", "sammy"],
+    ["nicholas", "nick", "nicky"],
+    ["alexander", "alex", "xander"],
+    ["alexandra", "alex", "lexi", "sandra"],
+    ["patrick", "pat", "paddy"],
+    ["patricia", "pat", "patty", "trish"],
+    ["peter", "pete"],
+    ["timothy", "tim", "timmy"],
+    ["gregory", "greg"],
+    ["ronald", "ron", "ronny"],
+    ["donald", "don", "donnie"],
+    ["kenneth", "ken", "kenny"],
+    ["lawrence", "larry"],
+    ["laurence", "larry"],
+    ["raymond", "ray"],
+    ["gerald", "jerry"],
+    ["henry", "hank", "harry"],
+    ["francis", "frank", "fran"],
+    ["franklin", "frank"],
+    ["frances", "fran", "frannie"],
+    ["philip", "phillip", "phil"],
+    ["theodore", "ted", "teddy", "theo"],
+    ["albert", "al", "bert"],
+    ["arthur", "art"],
+    ["frederick", "fred", "freddy"],
+    ["douglas", "doug"],
+    ["nathan", "nathaniel", "nate"],
+    ["zachary", "zac", "zach"],
+    ["jacob", "jake"],
+    ["joshua", "josh"],
+    ["jeffrey", "jeff"],
+    ["vincent", "vince", "vinny"],
+    ["russell", "russ"],
+    ["harold", "harry", "hal"],
+    ["stanley", "stan"],
+    ["leonard", "leo", "len"],
+    ["wesley", "wes"],
+    ["howard", "howie"],
+    ["norman", "norm"],
+    ["clifford", "cliff"],
+    ["ernest", "ernie"],
+    ["herbert", "herb"],
+    ["bernard", "bernie"],
+    ["maxwell", "max"],
+    ["gilbert", "gil"],
+    ["rodney", "rod"],
+    ["elizabeth", "liz", "lizzy", "beth", "betty", "eliza", "bess"],
+    ["jennifer", "jen", "jenny", "jenn"],
+    ["jessica", "jess", "jessie"],
+    ["barbara", "barb"],
+    ["susan", "sue", "suzy", "suzie"],
+    ["margaret", "maggie", "meg", "peggy", "marge"],
+    ["dorothy", "dot", "dotty"],
+    ["sandra", "sandy"],
+    ["kimberly", "kim"],
+    ["deborah", "deb", "debbie"],
+    ["stephanie", "steph"],
+    ["rebecca", "becky"],
+    ["cynthia", "cindy"],
+    ["kathleen", "kathy", "kate", "katie"],
+    ["katherine", "kate", "kathy", "katie", "katy"],
+    ["catherine", "cate", "cathy", "kate", "katie"],
+    ["victoria", "vicky", "tori"],
+    ["virginia", "ginny"],
+    ["pamela", "pam"],
+    ["judith", "judy"],
+    ["theresa", "teresa", "terry", "tess", "terri"],
+    ["eleanor", "ellie", "nell", "nellie"],
+    ["lillian", "lily", "lil"],
+    ["abigail", "abby"],
+    ["isabella", "izzy", "bella"],
+    ["charlotte", "charlie", "lottie"],
+    ["olivia", "liv", "livvy"],
+    ["natalie", "nat"],
+    ["megan", "meghan", "meg"],
+    ["angela", "angie"],
+    ["amanda", "mandy"],
+    ["nicole", "nikki"],
+    ["caroline", "carolyn", "carol", "carrie"],
+    ["melissa", "missy", "mel"],
+    ["michelle", "shelly"],
+    ["sarah", "sally"],
+    ["anne", "ann", "annie"],
+    ["sophia", "sophie"],
+];
+
+const GROUPS: ReadonlySet<string>[] = NICKNAME_GROUPS.map((group) => new Set(group));
+
+const NAME_TO_GROUPS = GROUPS.reduce((lookup, group, index) => {
+    group.forEach((name) => {
+        const groups = lookup.get(name) ?? [];
+        groups.push(index);
+        lookup.set(name, groups);
+    });
+    return lookup;
+}, new Map<string, number[]>());
+
+export function namesAreNicknames(left: string, right: string): boolean {
+    if (left === right) {
+        return false;
+    }
+    const groupIndexes = NAME_TO_GROUPS.get(left);
+    if (!groupIndexes) {
+        return false;
+    }
+    return groupIndexes.some((index) => GROUPS[index].has(right));
+}


### PR DESCRIPTION
## Summary
- Rewrite professor search ranking with nickname expansion and recency scoring
- Populate `lastRatingDate` on truncated professor index entries for ranking input
- Add unit tests for search ranking and nickname matching

## Test plan
- [ ] `npm t` in frontend (ProfessorSearch, nameNicknames specs)
- [ ] Manual search: nickname matches (e.g. Bob → Robert), recency affects ordering

Made with [Cursor](https://cursor.com)